### PR TITLE
[FE] Button 컴포넌트 구현

### DIFF
--- a/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
+++ b/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import Button from '@/components/_common/Button/Button';
 import TextArea from '@/components/_common/TextArea/TextArea';
 import { postFeed } from '@/apis/feed';
 import * as S from './FeedSubmit.css';
@@ -26,7 +27,9 @@ const FeedSubmit = () => {
       <TextArea value={content} onChange={(e) => setContent(e.target.value)}>
         <TextArea.Label label="설명" />
       </TextArea>
-      <button type="submit">제출</button>
+      <Button type="submit" color="primary">
+        제출
+      </Button>
     </form>
   );
 };

--- a/frontend/src/components/_common/Button/Button.css.ts
+++ b/frontend/src/components/_common/Button/Button.css.ts
@@ -1,0 +1,20 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const Base = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+
+  width: '100%',
+  height: '45px',
+  borderRadius: '15px',
+
+  font: vars.fonts.button,
+});
+
+export const Layout = styleVariants({
+  primary: [Base, { color: vars.colors.white, background: vars.colors.primary[800] }],
+  secondary: [Base, { color: vars.colors.white, background: vars.colors.secondary[700] }],
+  default: [Base, { color: vars.colors.primary[800], background: vars.colors.white }],
+});

--- a/frontend/src/components/_common/Button/Button.css.ts
+++ b/frontend/src/components/_common/Button/Button.css.ts
@@ -7,7 +7,7 @@ export const Base = style({
   alignItems: 'center',
 
   width: '100%',
-  height: '45px',
+  height: '44px',
   borderRadius: '15px',
 
   font: vars.fonts.button,

--- a/frontend/src/components/_common/Button/Button.stories.tsx
+++ b/frontend/src/components/_common/Button/Button.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Button from '@/components/_common/Button/Button';
+
+const meta = {
+  title: 'common/Button',
+  component: Button,
+  tags: ['autodocs'],
+  parameters: {
+    controls: { exclude: ['color'] },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: {
+    children: 'Hello World!',
+  },
+};
+
+export const Primary: Story = {
+  args: {
+    color: 'primary',
+    children: 'Hello World!',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    color: 'secondary',
+    children: 'Hello World!',
+  },
+};

--- a/frontend/src/components/_common/Button/Button.tsx
+++ b/frontend/src/components/_common/Button/Button.tsx
@@ -1,0 +1,17 @@
+import * as S from './Button.css';
+
+type ButtonColor = 'primary' | 'secondary' | 'default';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  color?: ButtonColor;
+}
+
+const Button = ({ color = 'default', children, ...props }: React.PropsWithChildren<ButtonProps>) => {
+  return (
+    <button type="button" className={S.Layout[color]} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
# 연관된 이슈
- closes: #18 

# 구현한 기능
- [x] Button 컴포넌트 구현
- [x] Button 컴포넌트 적용

# 구현한 내용
> <img width="439" alt="스크린샷 2024-12-03 오후 5 17 04" src="https://github.com/user-attachments/assets/99459e8e-fc58-4de7-ab22-564b6127437c">
- 다음과 같은 피그마 디자인을 바탕으로 컴포넌트 구현을 완료했습니다.
- 위에서부터 `default`, `primary`, `secondary` 로 타입을 설정했고, 각 타입 별로 조건부 스타일이 적용됩니다.
- `React.ButtonHTMLAttributes<HTMLButtonElement>` 을 상속하여 기본 HTML 버튼의 `props` 를 모두 사용할 수 있습니다.