### PR TITLE
[FE] Input 구현

### DIFF
--- a/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
+++ b/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '@/components/_common/Button/Button';
+import Input from '@/components/_common/Input/Input';
 import TextArea from '@/components/_common/TextArea/TextArea';
 import useFeedMutation from '@/queries/Feed/useFeedMutation';
 import * as S from './FeedSubmit.css';
@@ -28,6 +29,7 @@ const FeedSubmit = () => {
       <TextArea value={content} onChange={(e) => setContent(e.target.value)}>
         <TextArea.Label label="설명" />
       </TextArea>
+      <Input label="비밀번호" type="number" />
       <Button type="submit" color="primary">
         제출
       </Button>

--- a/frontend/src/components/_common/Input/Input.css.ts
+++ b/frontend/src/components/_common/Input/Input.css.ts
@@ -1,0 +1,33 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const Layout = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+});
+
+export const Label = style({
+  color: vars.colors.grey[700],
+  font: vars.fonts.label,
+});
+
+export const InputBase = style({
+  width: '100%',
+  height: '44px',
+  padding: '0 10px',
+  borderRadius: '10px',
+
+  background: vars.colors.grey[50],
+  font: vars.fonts.body,
+});
+
+export const Input = styleVariants({
+  default: [InputBase, { ':focus': { border: `1px solid ${vars.colors.grey[700]}` } }],
+  error: [InputBase, { border: `1px solid ${vars.colors.primary[800]}` }],
+});
+
+export const ErrorMessage = style({
+  color: vars.colors.primary[800],
+  font: vars.fonts.label,
+});

--- a/frontend/src/components/_common/Input/Input.stories.tsx
+++ b/frontend/src/components/_common/Input/Input.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Input from '@/components/_common/Input/Input';
+
+const meta = {
+  title: 'common/Input',
+  component: Input,
+  tags: ['autodocs'],
+  parameters: {
+    controls: { exclude: ['status'] },
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    label: '레이블',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    label: '레이블',
+    status: 'error',
+    errorMessage: '에러 메시지',
+  },
+};

--- a/frontend/src/components/_common/Input/Input.tsx
+++ b/frontend/src/components/_common/Input/Input.tsx
@@ -1,0 +1,19 @@
+import * as S from './Input.css';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  status?: 'default' | 'error';
+  errorMessage?: string;
+}
+
+const Input = ({ label, status = 'default', errorMessage, ...props }: InputProps) => {
+  return (
+    <div className={S.Layout}>
+      {label && <label className={S.Label}>{label}</label>}
+      <input className={S.Input[status]} {...props} />
+      {status === 'error' && errorMessage && <p className={S.ErrorMessage}>{errorMessage}</p>}
+    </div>
+  );
+};
+
+export default Input;


### PR DESCRIPTION
# 연관된 이슈
- closes: #19 

# 구현한 기능
- [x] Input 컴포넌트 구현

# 구현한 내용
- 아직은 디자인의 경우의 수가 많지 않아서 단순하게 조건부 렌더링으로 구현했습니다.
- 에러 메시지에 있는 아이콘의 경우 `react-icons` 의 [IoIosWarning](https://react-icons.github.io/react-icons/icons/io/)로 하려고 하는데 #30 PR이 머지되면 추후에 적용하도록 하겠습니다.