### PR TITLE
[BE] 이미지 조회 로직 수정

### DIFF
--- a/backend/src/main/java/com/christmas/feed/repository/entity/ImageFileEntity.java
+++ b/backend/src/main/java/com/christmas/feed/repository/entity/ImageFileEntity.java
@@ -23,14 +23,24 @@ public class ImageFileEntity extends TimestampEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
     @Column(name = "image_key", nullable = false)
     private String imageKey;
 
-    public ImageFileEntity(String imageKey) {
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    public ImageFileEntity(String fileName, String imageKey, String imageUrl) {
+        this.fileName = fileName;
         this.imageKey = imageKey;
+        this.imageUrl = imageUrl;
     }
 
-    public void updateImageKey(String imageKey) {
+    public void updateImage(String fileName, String imageKey, String imageUrl) {
+        this.fileName = fileName;
         this.imageKey = imageKey;
+        this.imageUrl = imageUrl;
     }
 }

--- a/backend/src/main/java/com/christmas/feed/service/FeedService.java
+++ b/backend/src/main/java/com/christmas/feed/service/FeedService.java
@@ -76,12 +76,13 @@ public class FeedService {
                         Map.of("id", String.valueOf(id)))
                 );
         FeedImageFileEntity feedImageFileEntity = feedImageFileRepository.findByFeedEntity(feedEntity);
-        URL imageUrl = imageFileService.getImageUrl(feedImageFileEntity.getImageFileEntity());
+        ImageFileEntity imageFileEntity = feedImageFileEntity.getImageFileEntity();
         return new FeedGetResponse(
-                feedEntity.getTreeEntity().getImageCode(),
+                feedEntity.getTreeEntity()
+                        .getImageCode(),
                 feedEntity.getNickname(),
-                latestUpdatedAt(feedEntity, feedImageFileEntity.getImageFileEntity()),
-                imageUrl.toString(),
+                latestUpdatedAt(feedEntity, imageFileEntity),
+                imageFileEntity.getImageUrl(),
                 feedEntity.getContent(),
                 feedEntity.getLikeCount()
         );
@@ -98,12 +99,11 @@ public class FeedService {
         for (FeedEntity feedEntity : feedEntities) {
             ImageFileEntity imageFileEntity = feedImageFileRepository.findByFeedEntity(feedEntity)
                     .getImageFileEntity();
-            URL imageUrl = imageFileService.getImageUrl(imageFileEntity);
             response.add(new FeedGetResponse(
                     treeEntity.getImageCode(),
                     feedEntity.getNickname(),
                     latestUpdatedAt(feedEntity, imageFileEntity),
-                    imageUrl.toString(),
+                    imageFileEntity.getImageUrl(),
                     feedEntity.getContent(),
                     feedEntity.getLikeCount())
             );

--- a/backend/src/main/java/com/christmas/feed/service/ImageFileService.java
+++ b/backend/src/main/java/com/christmas/feed/service/ImageFileService.java
@@ -20,23 +20,17 @@ public class ImageFileService {
     private final ImageFileRepository imageFileRepository;
     private final S3ImageManager s3ImageManager;
 
-    // todo 메서드명 간단하게 변경
     public ImageFileEntity createImage(MultipartFile image) {
         String key = UUID.randomUUID() + image.getOriginalFilename();
-        s3ImageManager.upload(key, image);
-        return imageFileRepository.save(new ImageFileEntity(key));
+        final URL imageUrl = s3ImageManager.upload(key, image);
+        return imageFileRepository.save(new ImageFileEntity(image.getOriginalFilename(), key, imageUrl.toString()));
     }
 
-    public URL getImageUrl(ImageFileEntity imageFileEntity) {
-        String s3Key = imageFileEntity.getImageKey();
-        return s3ImageManager.getUrlByKey(s3Key);
-    }
-
-    public URL updateImage(ImageFileEntity imageFileEntity, MultipartFile image) {
+    public URL updateImage(ImageFileEntity imageFileEntity, MultipartFile newImage) {
         String oldKey = imageFileEntity.getImageKey();
-        String newKey = UUID.randomUUID() + image.getOriginalFilename();
-        URL url = s3ImageManager.upload(newKey, image);
-        imageFileEntity.updateImageKey(newKey);
+        String newKey = UUID.randomUUID() + newImage.getOriginalFilename();
+        URL url = s3ImageManager.upload(newKey, newImage);
+        imageFileEntity.updateImage(newImage.getOriginalFilename(), newKey, url.toString());
         s3ImageManager.deleteByKey(oldKey);
         return url;
     }


### PR DESCRIPTION
## 기존 방식
- s3 key를 사용해서 s3에서 이미지 url 가져오기
## 변경한 방식
- 이미지를 생성할 때 url을 db에 저장하고, 조회 시 s3가 아닌 db에서 이미지 url 가져오기