### PR TITLE
[BE] api void 응답 모두 바디로 대체 Issue #61

### DIFF
--- a/backend/src/main/java/com/christmas/feed/controller/FeedController.java
+++ b/backend/src/main/java/com/christmas/feed/controller/FeedController.java
@@ -23,6 +23,7 @@ import com.christmas.feed.dto.FeedCreateRequest;
 import com.christmas.feed.dto.FeedDeleteRequest;
 import com.christmas.feed.dto.FeedGetResponse;
 import com.christmas.feed.dto.FeedUpdateRequest;
+import com.christmas.feed.dto.FeedUpdateResponse;
 import com.christmas.feed.service.FeedService;
 
 import lombok.RequiredArgsConstructor;
@@ -61,27 +62,27 @@ public class FeedController implements FeedControllerDocs {
             value = "/feed/{id}",
             consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE}
     )
-    public ResponseEntity<Void> updateFeed(
+    public ResponseEntity<FeedUpdateResponse> updateFeed(
             @PathVariable("id") long id,
-            @RequestPart(value = "image", required = false) MultipartFile image,
+            @RequestPart("image") MultipartFile image,
             @RequestPart("request") FeedUpdateRequest request
     ) {
-        feedService.updateFeed(id, image, request);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .build();
+        FeedUpdateResponse response = feedService.updateFeed(id, image, request);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(response);
     }
 
     @DeleteMapping("/feed/{id}")
-    public ResponseEntity<Void> deleteFeed(@PathVariable("id") long id, @RequestBody FeedDeleteRequest request) {
-        feedService.deleteFeed(id, request.password());
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .build();
+    public ResponseEntity<Long> deleteFeed(@PathVariable("id") long id, @RequestBody FeedDeleteRequest request) {
+        long deletedId = feedService.deleteFeed(id, request.password());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(deletedId);
     }
 
     @DeleteMapping("/feed/{id}/like")
-    public ResponseEntity<Void> deleteLike(@PathVariable("id") long id) {
-        feedService.deleteLike(id);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .build();
+    public ResponseEntity<Long> deleteLike(@PathVariable("id") long id) {
+        long likeCount = feedService.deleteLike(id);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(likeCount);
     }
 }

--- a/backend/src/main/java/com/christmas/feed/controller/FeedControllerDocs.java
+++ b/backend/src/main/java/com/christmas/feed/controller/FeedControllerDocs.java
@@ -11,6 +11,7 @@ import com.christmas.feed.dto.FeedCreateRequest;
 import com.christmas.feed.dto.FeedDeleteRequest;
 import com.christmas.feed.dto.FeedGetResponse;
 import com.christmas.feed.dto.FeedUpdateRequest;
+import com.christmas.feed.dto.FeedUpdateResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -56,13 +57,13 @@ public interface FeedControllerDocs {
     ResponseEntity<List<FeedGetResponse>> getAllFeed(@Parameter(description = "treeId", required = true) long treeId);
 
     @Operation(summary = "피드를 수정한다.")
-    @ApiResponse(responseCode = "200", description = "피드 수정에 성공 시 수정 시간, 이미지 url, 피드 내용을 반환한다.",
+    @ApiResponse(responseCode = "200", description = "피드 수정에 성공 시 id, 이미지 url, 피드 내용을 반환한다.",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, array = @ArraySchema(schema = @Schema(implementation = FeedGetResponse.class)))
     )
     @ApiResponse(responseCode = "4XX", description = "피드 수정 실패 시 예외를 반환한다.",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ExceptionResponse.class))
     )
-    ResponseEntity<Void> updateFeed(
+    ResponseEntity<FeedUpdateResponse> updateFeed(
             @Parameter(description = "피드 id", required = true)
             long id,
             @Parameter(description = "이미지 파일", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
@@ -72,11 +73,13 @@ public interface FeedControllerDocs {
     );
 
     @Operation(summary = "피드를 삭제한다.")
-    @ApiResponse(responseCode = "204", description = "피드 삭제에 성공한다.")
+    @ApiResponse(responseCode = "200", description = "피드 삭제에 성공한다. 성공하면 삭제한 피드 id를 반환한다.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = Long.class))
+    )
     @ApiResponse(responseCode = "4XX", description = "피드 삭제 실패 시 예외를 반환한다.",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ExceptionResponse.class))
     )
-    ResponseEntity<Void> deleteFeed(
+    ResponseEntity<Long> deleteFeed(
             @Parameter(description = "피드 id", required = true)
             long id,
             @Parameter(description = "비밀번호", example = "abs123", required = true)
@@ -84,9 +87,11 @@ public interface FeedControllerDocs {
     );
 
     @Operation(summary = "좋아요를 취소한다.")
-    @ApiResponse(responseCode = "204", description = "좋아요 취소에 성공한다.")
+    @ApiResponse(responseCode = "200", description = "좋아요 취소에 성공한다. 성공하면 현재 좋아요 수를 반환한다.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = Long.class))
+    )
     @ApiResponse(responseCode = "4XX", description = "좋아요 취소에 실패한다.",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ExceptionResponse.class))
     )
-    ResponseEntity<Void> deleteLike(@Parameter(description = "피드 id", required = true) long id);
+    ResponseEntity<Long> deleteLike(@Parameter(description = "피드 id", required = true) long id);
 }

--- a/backend/src/main/java/com/christmas/feed/dto/FeedUpdateResponse.java
+++ b/backend/src/main/java/com/christmas/feed/dto/FeedUpdateResponse.java
@@ -1,0 +1,14 @@
+package com.christmas.feed.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "피드 수정 응답")
+public record FeedUpdateResponse(
+        @Schema(description = "피드 id")
+        long id,
+        @Schema(description = "피드에 삽입된 이미지", example = "크리스마스.jpg")
+        String imageUrl,
+        @Schema(description = "피드 내용")
+        String content
+) {
+}

--- a/backend/src/main/java/com/christmas/feed/exception/NegativeValueException.java
+++ b/backend/src/main/java/com/christmas/feed/exception/NegativeValueException.java
@@ -1,0 +1,12 @@
+package com.christmas.feed.exception;
+
+import java.util.Map;
+
+import com.christmas.common.exception.CustomErrorCode;
+import com.christmas.common.exception.CustomException;
+
+public class NegativeValueException extends CustomException {
+    public NegativeValueException(CustomErrorCode errorCode, Map<String, String> invalidData) {
+        super(errorCode, invalidData);
+    }
+}

--- a/backend/src/main/java/com/christmas/feed/exception/code/FeedErrorCode.java
+++ b/backend/src/main/java/com/christmas/feed/exception/code/FeedErrorCode.java
@@ -15,7 +15,8 @@ public enum FeedErrorCode implements CustomErrorCode {
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 챶을 수 없습니다."),
     IMAGE_DELETE_FAIL(HttpStatus.UNPROCESSABLE_ENTITY, "이미지 삭제 요청을 처리하던 중 오류가 발생했습니다."),
     FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "피드를 찾을 수 없습니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다.")
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다."),
+    NEGATIVE_LIKE_COUNT(HttpStatus.BAD_REQUEST, "좋아요 수가 0이기 때문에 좋아요를 취소할 수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/backend/src/main/java/com/christmas/feed/repository/entity/FeedEntity.java
+++ b/backend/src/main/java/com/christmas/feed/repository/entity/FeedEntity.java
@@ -1,5 +1,7 @@
 package com.christmas.feed.repository.entity;
 
+import java.util.Map;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -15,6 +17,8 @@ import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Length;
 
 import com.christmas.common.application.TimestampEntity;
+import com.christmas.feed.exception.NegativeValueException;
+import com.christmas.feed.exception.code.FeedErrorCode;
 import com.christmas.tree.repository.TreeEntity;
 
 import lombok.AccessLevel;
@@ -68,6 +72,9 @@ public class FeedEntity extends TimestampEntity {
     }
 
     public void removeLike() {
+        if (likeCount == 0) {
+            throw new NegativeValueException(FeedErrorCode.NEGATIVE_LIKE_COUNT, Map.of("likeCount", "0"));
+        }
         likeCount--;
     }
 


### PR DESCRIPTION
## 연관된 이슈
- closes: #61 

## 구현한 내용
- 타입 안정성을 위해 모든 응답에 body를 담아 전송