### PR TITLE
[BE] 코스 추천 시 보행자 경로 좌표 추가 Issue #91

### DIFF
--- a/backend/src/main/java/com/christmas/infrastructure/route/dto/RouteInfo.java
+++ b/backend/src/main/java/com/christmas/infrastructure/route/dto/RouteInfo.java
@@ -1,11 +1,14 @@
 package com.christmas.infrastructure.route.dto;
 
+import java.util.List;
 import java.util.Map;
 
 import com.christmas.infrastructure.route.domain.FacilityType;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public record RouteInfo(
         int totalSeconds,
-        Map<FacilityType, Integer> facilityInfo
+        Map<FacilityType, Integer> facilityInfo,
+        List<JsonNode> route
 ) {
 }

--- a/backend/src/main/java/com/christmas/recommend/dto/PedestrianRoute.java
+++ b/backend/src/main/java/com/christmas/recommend/dto/PedestrianRoute.java
@@ -1,9 +1,13 @@
 package com.christmas.recommend.dto;
 
+import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 public record PedestrianRoute(
         int durationMinutes,
-        Map<String, Integer> facilityType
+        Map<String, Integer> facilityType,
+        List<JsonNode> route
 ) {
 }

--- a/backend/src/main/java/com/christmas/recommend/service/RecommendService.java
+++ b/backend/src/main/java/com/christmas/recommend/service/RecommendService.java
@@ -79,35 +79,47 @@ public class RecommendService {
         // 1. 현재 위치에서 점심
 
         RouteInfo lunchRoute = parser.getDistanceInfo(PointType.SP, PointType.PP1);
-        PedestrianRoute lunchInfo = new PedestrianRoute(lunchRoute.totalSeconds() / 60,
-                makeFacilityInfo(lunchRoute.facilityInfo()));
+        PedestrianRoute lunchInfo = new PedestrianRoute(
+                lunchRoute.totalSeconds() / 60,
+                makeFacilityInfo(lunchRoute.facilityInfo()),
+                lunchRoute.route()
+        );
         JsonNode lunchInfoJson = mapper.valueToTree(lunchInfo);
         ObjectNode lunchResult = (ObjectNode) lunch;
-        lunchResult.set("pedestrian_route", lunchInfoJson);
+        lunchResult.set("pedestrian", lunchInfoJson);
 
         // 2. 점심에서 카페
         RouteInfo cafeRoute = parser.getDistanceInfo(PointType.PP1, PointType.PP2);
-        PedestrianRoute cafeInfo = new PedestrianRoute(cafeRoute.totalSeconds() / 60,
-                makeFacilityInfo(cafeRoute.facilityInfo()));
+        PedestrianRoute cafeInfo = new PedestrianRoute(
+                cafeRoute.totalSeconds() / 60,
+                makeFacilityInfo(cafeRoute.facilityInfo()),
+                cafeRoute.route()
+        );
         JsonNode cafeInfoJson = mapper.valueToTree(cafeInfo);
         ObjectNode cafeResult = (ObjectNode) cafe;
-        cafeResult.set("pedestrian_route", cafeInfoJson);
+        cafeResult.set("pedestrian", cafeInfoJson);
 
         // 3. 카페에서 어트랙션
         RouteInfo attractionRoute = parser.getDistanceInfo(PointType.PP2, PointType.PP3);
-        PedestrianRoute attractionInfo = new PedestrianRoute(attractionRoute.totalSeconds() / 60,
-                makeFacilityInfo(attractionRoute.facilityInfo()));
+        PedestrianRoute attractionInfo = new PedestrianRoute(
+                attractionRoute.totalSeconds() / 60,
+                makeFacilityInfo(attractionRoute.facilityInfo()),
+                attractionRoute.route()
+        );
         JsonNode attractionInfoJson = mapper.valueToTree(attractionInfo);
         ObjectNode attractionResult = (ObjectNode) attraction;
-        attractionResult.set("pedestrian_route", attractionInfoJson);
+        attractionResult.set("pedestrian", attractionInfoJson);
 
         // 4. 어트랙션에서 저녁
         RouteInfo dinnerRoute = parser.getDistanceInfo(PointType.PP3, PointType.EP);
-        PedestrianRoute dinnerInfo = new PedestrianRoute(dinnerRoute.totalSeconds() / 60,
-                makeFacilityInfo(dinnerRoute.facilityInfo()));
+        PedestrianRoute dinnerInfo = new PedestrianRoute(
+                dinnerRoute.totalSeconds() / 60,
+                makeFacilityInfo(dinnerRoute.facilityInfo()),
+                dinnerRoute.route()
+        );
         JsonNode dinnerInfoJson = mapper.valueToTree(dinnerInfo);
         ObjectNode dinnerResult = (ObjectNode) dinner;
-        dinnerResult.set("pedestrian_route", dinnerInfoJson);
+        dinnerResult.set("pedestrian", dinnerInfoJson);
 
         return new CourseGetResponse(lunchResult, cafeResult, attractionResult, dinnerResult);
     }


### PR DESCRIPTION
## 📌 연관된 이슈

- closes: #91 

## ✨ 구현한 기능
- 코스 추천 시 장소와 장소 사이 거리의 좌표를 함께 반환

## ✏️ 자세한 구현 내용
- 리스트 형태로 x 좌표, y 좌표를 반환한다. 좌표와 좌표 사이는 일직선이다.
- "pedestrian" 필드의 "route"에 좌표 리스트가 있다.
```JSON
     "route": [
                [
                    127.04745224000158,
                    37.51752828350357
                ],
                [
                    127.04741612918762,
                    37.51763382614731
                ],
                [
                    127.04737724021929,
                    37.517761588381674
                ],
                [
                    127.04726612899358,
                    37.518122655543905
                ]
            ]
```
