### PR TITLE
[BE] 추천 장소 결과가 Null일 경우, 경로 계산을 하지 않도록 예외 처리 Issue #92

### DIFF
--- a/backend/src/main/java/com/christmas/infrastructure/route/domain/PointType.java
+++ b/backend/src/main/java/com/christmas/infrastructure/route/domain/PointType.java
@@ -1,5 +1,10 @@
 package com.christmas.infrastructure.route.domain;
 
+import java.util.Map;
+
+import com.christmas.infrastructure.route.exception.NotFoundPointType;
+import com.christmas.infrastructure.route.exception.code.DistanceErrorCode;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -16,4 +21,13 @@ public enum PointType {
     GP("일반 안내점");
 
     private final String description;
+
+    public static PointType findByName(String name) {
+        for (PointType pointType : PointType.values()) {
+            if (pointType.name().equals(name)) {
+                return pointType;
+            }
+        }
+        throw new NotFoundPointType(DistanceErrorCode.NOT_FOUND_POINT_TYPE_BY_NAME, Map.of("pointType name", name));
+    }
 }

--- a/backend/src/main/java/com/christmas/infrastructure/route/exception/NotFoundPointType.java
+++ b/backend/src/main/java/com/christmas/infrastructure/route/exception/NotFoundPointType.java
@@ -1,0 +1,12 @@
+package com.christmas.infrastructure.route.exception;
+
+import java.util.Map;
+
+import com.christmas.common.exception.CustomErrorCode;
+import com.christmas.common.exception.CustomException;
+
+public class NotFoundPointType extends CustomException {
+    public NotFoundPointType(CustomErrorCode errorCode, Map<String, Object> invalidData) {
+        super(errorCode, invalidData);
+    }
+}

--- a/backend/src/main/java/com/christmas/infrastructure/route/exception/code/DistanceErrorCode.java
+++ b/backend/src/main/java/com/christmas/infrastructure/route/exception/code/DistanceErrorCode.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum DistanceErrorCode implements CustomErrorCode {
 
-    NOT_EXIST_FACILITY_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "해당 시설물 code가 존재하지 않습니다.");
+    NOT_EXIST_FACILITY_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "해당 시설물 code가 존재하지 않습니다."),
+    NOT_FOUND_POINT_TYPE_BY_NAME(HttpStatus.INTERNAL_SERVER_ERROR, "point type 이름으로 변수를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/com/christmas/infrastructure/route/service/RouteApiBody.java
+++ b/backend/src/main/java/com/christmas/infrastructure/route/service/RouteApiBody.java
@@ -22,11 +22,13 @@ public class RouteApiBody {
         body.put("endX", condition.end().x());
         body.put("endY", condition.end().y());
         body.put("endName", condition.endName());
-        String passList = condition.passList()
-                .stream()
-                .map(xy -> String.format(XY_DELIMITER_FORMAT, xy.x(), xy.y()))
-                .collect(Collectors.joining(PASS_LIST_DELIMITER));
-        body.put("passList", passList);
+        if (!condition.passList().isEmpty()) {
+            String passList = condition.passList()
+                    .stream()
+                    .map(xy -> String.format(XY_DELIMITER_FORMAT, xy.x(), xy.y()))
+                    .collect(Collectors.joining(PASS_LIST_DELIMITER));
+            body.put("passList", passList);
+        }
         body.put("searchOption", 4);
         return body;
     }

--- a/backend/src/main/java/com/christmas/recommend/service/RecommendService.java
+++ b/backend/src/main/java/com/christmas/recommend/service/RecommendService.java
@@ -2,6 +2,7 @@ package com.christmas.recommend.service;
 
 import static com.christmas.recommend.domain.RecommendKeyword.getKeywords;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -61,67 +62,94 @@ public class RecommendService {
         JsonNode cafe = getRandomLocation(cafes);
         JsonNode attraction = getRandomLocation(attractions);
 
-        // todo: 각 값이 null일 경우 체크.
-        XY nowXY = new XY(request.longitude(), request.latitude());
-        XY lunchXY = searchApiParser.extractXYFromLocation(lunch);
-        XY cafeXY = searchApiParser.extractXYFromLocation(cafe);
-        XY attractionXY = searchApiParser.extractXYFromLocation(attraction);
-        XY dinnerXY = searchApiParser.extractXYFromLocation(dinner);
-        RouteConditionDto condition = new RouteConditionDto(nowXY, "현재 위치", dinnerXY, "코스 마지막 위치",
-                List.of(lunchXY, cafeXY, attractionXY));
+        List<XY> locationsNotNull = new ArrayList<>();
+        locationsNotNull.add(new XY(request.longitude(), request.latitude())); // 무조건 존재
+        if (lunch != null) {
+            locationsNotNull.add(searchApiParser.extractXYFromLocation(lunch));
+        }
+        if (cafe != null) {
+            locationsNotNull.add(searchApiParser.extractXYFromLocation(cafe));
+        }
+        if (attraction != null) {
+            locationsNotNull.add(searchApiParser.extractXYFromLocation(attraction));
+        }
+        if (dinner != null) {
+            locationsNotNull.add(searchApiParser.extractXYFromLocation(dinner));
+        }
+
+        if (locationsNotNull.size() == 1) {
+            return new CourseGetResponse(null, null, null, null);
+        }
+        RouteConditionDto condition = makeRouteCondition(locationsNotNull);
         JsonNode routesDistance = routeApiManager.getPedestrianRoute(condition).block();
 
+        // 경로 계산 로직
         ObjectMapper mapper = new ObjectMapper();
         mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+        List<RouteInfo> routes = getRoutes(locationsNotNull, routesDistance);
+        int count = 0;
 
-        // 경로 계산 로직
-        RouteApiParser parser = RouteApiParser.from(routesDistance);
-        // 1. 현재 위치에서 점심
+        RouteInfo lunchRoute = lunch != null ? routes.get(count++) : null;
+        ObjectNode lunchResult = makeRoute(lunch, lunchRoute, mapper);
 
-        RouteInfo lunchRoute = parser.getDistanceInfo(PointType.SP, PointType.PP1);
-        PedestrianRoute lunchInfo = new PedestrianRoute(
-                lunchRoute.totalSeconds() / 60,
-                makeFacilityInfo(lunchRoute.facilityInfo()),
-                lunchRoute.route()
-        );
-        JsonNode lunchInfoJson = mapper.valueToTree(lunchInfo);
-        ObjectNode lunchResult = (ObjectNode) lunch;
-        lunchResult.set("pedestrian", lunchInfoJson);
+        RouteInfo cafeRoute = cafe != null ? routes.get(count++) : null;
+        ObjectNode cafeResult = makeRoute(cafe, cafeRoute, mapper);
 
-        // 2. 점심에서 카페
-        RouteInfo cafeRoute = parser.getDistanceInfo(PointType.PP1, PointType.PP2);
-        PedestrianRoute cafeInfo = new PedestrianRoute(
-                cafeRoute.totalSeconds() / 60,
-                makeFacilityInfo(cafeRoute.facilityInfo()),
-                cafeRoute.route()
-        );
-        JsonNode cafeInfoJson = mapper.valueToTree(cafeInfo);
-        ObjectNode cafeResult = (ObjectNode) cafe;
-        cafeResult.set("pedestrian", cafeInfoJson);
+        RouteInfo attractionRoute = attraction != null ? routes.get(count++) : null;
+        ObjectNode attractionResult = makeRoute(attraction, attractionRoute, mapper);
 
-        // 3. 카페에서 어트랙션
-        RouteInfo attractionRoute = parser.getDistanceInfo(PointType.PP2, PointType.PP3);
-        PedestrianRoute attractionInfo = new PedestrianRoute(
-                attractionRoute.totalSeconds() / 60,
-                makeFacilityInfo(attractionRoute.facilityInfo()),
-                attractionRoute.route()
-        );
-        JsonNode attractionInfoJson = mapper.valueToTree(attractionInfo);
-        ObjectNode attractionResult = (ObjectNode) attraction;
-        attractionResult.set("pedestrian", attractionInfoJson);
-
-        // 4. 어트랙션에서 저녁
-        RouteInfo dinnerRoute = parser.getDistanceInfo(PointType.PP3, PointType.EP);
-        PedestrianRoute dinnerInfo = new PedestrianRoute(
-                dinnerRoute.totalSeconds() / 60,
-                makeFacilityInfo(dinnerRoute.facilityInfo()),
-                dinnerRoute.route()
-        );
-        JsonNode dinnerInfoJson = mapper.valueToTree(dinnerInfo);
-        ObjectNode dinnerResult = (ObjectNode) dinner;
-        dinnerResult.set("pedestrian", dinnerInfoJson);
-
+        RouteInfo dinnerRoute = dinner != null ? routes.get(count) : null;
+        ObjectNode dinnerResult = makeRoute(dinner, dinnerRoute, mapper);
         return new CourseGetResponse(lunchResult, cafeResult, attractionResult, dinnerResult);
+    }
+
+    private ObjectNode makeRoute(JsonNode location, RouteInfo routeInfo, ObjectMapper mapper) {
+        if (location == null) {
+            return null;
+        }
+        PedestrianRoute route = new PedestrianRoute(
+                routeInfo.totalSeconds() / 60,
+                makeFacilityInfo(routeInfo.facilityInfo()),
+                routeInfo.route()
+        );
+        JsonNode infoJson = mapper.valueToTree(route);
+        ObjectNode result = (ObjectNode) location;
+        result.set("pedestrian", infoJson);
+        return result;
+    }
+
+    private RouteConditionDto makeRouteCondition(List<XY> locationsNotNull) {
+        if (locationsNotNull.size() == 2) {
+            return new RouteConditionDto(locationsNotNull.get(0), "시작 장소", locationsNotNull.get(1), "종료 장소", List.of());
+        }
+        List<XY> passPlace = new ArrayList<>();
+        for (int i = 1; i < locationsNotNull.size() - 1; i++) {
+            passPlace.add(locationsNotNull.get(i));
+        }
+        return new RouteConditionDto(locationsNotNull.get(0), "시작 장소",
+                locationsNotNull.get(locationsNotNull.size() - 1), "종료 장소", passPlace);
+    }
+
+    private List<RouteInfo> getRoutes(List<XY> locationsNotNull, JsonNode routesDistance) {
+        RouteApiParser parser = RouteApiParser.from(routesDistance);
+        if (locationsNotNull.size() == 2) {
+            return List.of(parser.getDistanceInfo(PointType.SP, PointType.EP));
+        }
+
+        List<RouteInfo> routeInfos = new ArrayList<>();
+        for (int i = 0; i < locationsNotNull.size() - 1; i++) {
+            if (i == 0) {
+                routeInfos.add(parser.getDistanceInfo(PointType.SP, PointType.PP1));
+            } else if (i == locationsNotNull.size() - 2) {
+                PointType start = PointType.findByName("PP" + i);
+                routeInfos.add(parser.getDistanceInfo(start, PointType.EP));
+            } else {
+                PointType start = PointType.findByName("PP" + i);
+                PointType end = PointType.findByName("PP" + (i + 1));
+                routeInfos.add(parser.getDistanceInfo(start, end));
+            }
+        }
+        return routeInfos;
     }
 
     private List<JsonNode> findLocationsByKeyword(CourseGetRequest request, LocationCategory category) {


### PR DESCRIPTION
## 📌 연관된 이슈

- closes: #92 

## ✨ 구현한 기능
- 추천 장소가 null일 경우, 해당 장소를 건너뛰고 보도 거리 계산을 하도록 수정

## ✏️ 자세한 구현 내용
- 점심, 카페, 볼거리, 저녁 중 카카오맵 장소 검색 결과가 null인 장소가 존재한다면, 해당 장소를 건너뛰고 보도 거리를 계산한다.
- 만약 카페가 null이라면, 볼거리의 보도 거리는 카페-볼거리 사이 거리가 아니라 점심-볼거리 사이 거리를 계산하도록 한다.
