### PR TITLE
[FE] 피드 제출 시 밸리데이션 Issue #90

### DIFF
--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -29,7 +29,7 @@ export const postFeed = async ({ imageFile, treeId, content, password }: PostFee
   formData.append('image', imageFile);
   formData.append('request', blob);
 
-  await requestAPI.post<number>('/feed', formData);
+  requestAPI.post('/feed', formData);
 };
 
 interface PostLikeFeedRequest {

--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -29,7 +29,7 @@ export const postFeed = async ({ imageFile, treeId, content, password }: PostFee
   formData.append('image', imageFile);
   formData.append('request', blob);
 
-  requestAPI.post('/feed', formData);
+  await requestAPI.post('/feed', formData);
 };
 
 interface PostLikeFeedRequest {

--- a/frontend/src/components/Feed/FeedList/FeedList.css.ts
+++ b/frontend/src/components/Feed/FeedList/FeedList.css.ts
@@ -5,7 +5,7 @@ export const Layout = style({
   flexDirection: 'column',
   gap: '40px',
 
-  height: '1px',
+  height: 'fit-content',
 
   boxShadow: '6px 0 30px 0 rgba(0, 0, 0, 0.12), 12px 0px 38px 0 rgba(0, 0, 0, 0.08)',
 });

--- a/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
+++ b/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
@@ -20,6 +20,8 @@ const FeedSubmit = () => {
     content,
     password,
     center,
+    isContentError,
+    isPasswordError,
     handleContentChange,
     handlePasswordChange,
     handleSubmit,
@@ -67,10 +69,23 @@ const FeedSubmit = () => {
         <input type="file" accept="image/*" onChange={handleImageChange} className={S.ImageInput} ref={fileInputRef} />
       </div>
 
-      <TextArea value={content} onChange={handleContentChange}>
+      <TextArea
+        value={content}
+        onChange={handleContentChange}
+        status={isContentError ? 'error' : 'default'}
+        errorMessage="내용을 작성해 주세요."
+      >
         <TextArea.Label label="설명" />
       </TextArea>
-      <Input label="비밀번호" buttonType="submit" type="password" value={password} onChange={handlePasswordChange} />
+      <Input
+        label="비밀번호"
+        buttonType="submit"
+        type="password"
+        value={password}
+        onChange={handlePasswordChange}
+        status={isPasswordError ? 'error' : 'default'}
+        errorMessage="영문과 숫자 조합으로 8자 이상 16자 이하로 작성해 주세요."
+      />
       <Button type="submit" color="primary">
         제출
       </Button>

--- a/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
+++ b/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
@@ -86,7 +86,7 @@ const FeedSubmit = () => {
         status={isPasswordError ? 'error' : 'default'}
         errorMessage="영문과 숫자 조합으로 8자 이상 16자 이하로 작성해 주세요."
       />
-      <Button type="submit" color="primary">
+      <Button type="submit" color="primary" disabled={isContentError || isPasswordError ? true : false}>
         제출
       </Button>
     </form>

--- a/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
+++ b/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
@@ -7,6 +7,7 @@ import TextArea from '@/components/_common/TextArea/TextArea';
 import useFeedSubmit from '@/hooks/Feed/useFeedSubmit';
 import useImageUploader from '@/hooks/Feed/useImageUploader';
 import useTreeMap from '@/hooks/TreeMap/useTreeMap';
+import { FEED } from '@/constants/feed';
 import mapIcon from '@/assets/map.png';
 import * as S from './FeedSubmit.css';
 
@@ -74,6 +75,7 @@ const FeedSubmit = () => {
         onChange={handleContentChange}
         status={isContentError ? 'error' : 'default'}
         errorMessage="내용을 작성해 주세요."
+        maxLength={FEED.contentMaxLength}
       >
         <TextArea.Label label="설명" />
       </TextArea>

--- a/frontend/src/components/_common/Modal/Modal.css.ts
+++ b/frontend/src/components/_common/Modal/Modal.css.ts
@@ -87,7 +87,7 @@ const ContainerBase = style({
   zIndex: 200,
 
   width: '100%',
-  height: '100vh',
+  height: 'calc(100vh - 48px)',
 
   padding: '33px 24px 0',
 
@@ -110,7 +110,7 @@ export const ContentWrapper = style({
 
   width: '100%',
   height: '100%',
-  padding: '17px 0',
+  padding: '17px 0 34px',
 
   /* 크롬, 사파리, 오페라 */
   '::-webkit-scrollbar': {

--- a/frontend/src/constants/feed.ts
+++ b/frontend/src/constants/feed.ts
@@ -1,0 +1,3 @@
+export const FEED = {
+  contentMaxLength: 300,
+};

--- a/frontend/src/hooks/Feed/useFeedSubmit.ts
+++ b/frontend/src/hooks/Feed/useFeedSubmit.ts
@@ -3,6 +3,7 @@ import { Location, NavigateFunction } from 'react-router-dom';
 import useFeedMutation from '@/queries/Feed/useFeedMutation';
 import useTreeMutation from '@/queries/Tree/useTreeMutation';
 import useTreesQuery from '@/queries/Tree/useTreesQuery';
+import { validateContent, validatePassword } from '@/utils/validate';
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
 
 interface UseFeedSubmitProps {
@@ -14,33 +15,56 @@ interface UseFeedSubmitProps {
 const useFeedSubmit = ({ imageFile, location, navigate }: UseFeedSubmitProps) => {
   const [content, setContent] = useState('');
   const [password, setPassword] = useState('');
-  const [treeId, setTreeId] = useState<number>(location.state?.treeId ?? 0);
   const center: { latitude: number; longitude: number } = location.state?.center ?? {
     latitude: DEFAULT_LATITUDE,
     longitude: DEFAULT_LONGITUDE,
   };
 
+  const [isContentError, setIsContentError] = useState(false);
+  const [isPasswordError, setIsPasswordError] = useState(false);
+
   const { addFeedMutation } = useFeedMutation();
   const { addTree } = useTreeMutation();
   const { trees } = useTreesQuery(center);
 
-  const handleContentChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => setContent(event.target.value);
-  const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => setPassword(event.target.value);
+  const handleContentChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const content = event.target.value;
+
+    if (!validateContent(content)) {
+      setIsContentError(true);
+    } else {
+      setIsContentError(false);
+    }
+
+    setContent(content);
+  };
+
+  const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const password = event.target.value;
+
+    if (!validatePassword(password)) {
+      setIsPasswordError(true);
+    } else {
+      setIsPasswordError(false);
+    }
+
+    setPassword(password);
+  };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!imageFile) return;
+    if (!imageFile || isPasswordError || isContentError) return;
 
-    let currentTreeId = treeId;
+    // 주변 트리 탐색 후 트리가 있다면 가장 가까운 트리 ID에 피드 제출
+    let currentTreeId = trees.length > 0 ? trees[0].id : 0;
 
-    if (!trees || trees.length === 0 || treeId === 0) {
+    if (!trees || trees.length === 0 || currentTreeId === 0) {
       currentTreeId = await addTree({
         latitude: center.latitude,
         longitude: center.longitude,
         imageCode: 'TREE_01',
       });
-      setTreeId(currentTreeId);
     }
 
     await addFeedMutation({
@@ -57,6 +81,8 @@ const useFeedSubmit = ({ imageFile, location, navigate }: UseFeedSubmitProps) =>
     content,
     password,
     center,
+    isContentError,
+    isPasswordError,
     handleContentChange,
     handlePasswordChange,
     handleSubmit,

--- a/frontend/src/hooks/Feed/useFeedSubmit.ts
+++ b/frontend/src/hooks/Feed/useFeedSubmit.ts
@@ -20,8 +20,8 @@ const useFeedSubmit = ({ imageFile, location, navigate }: UseFeedSubmitProps) =>
     longitude: DEFAULT_LONGITUDE,
   };
 
-  const [isContentError, setIsContentError] = useState(false);
-  const [isPasswordError, setIsPasswordError] = useState(false);
+  const [isContentError, setIsContentError] = useState(true);
+  const [isPasswordError, setIsPasswordError] = useState(true);
 
   const { addFeedMutation } = useFeedMutation();
   const { addTree } = useTreeMutation();

--- a/frontend/src/hooks/TreeMap/useTreeMap.ts
+++ b/frontend/src/hooks/TreeMap/useTreeMap.ts
@@ -2,12 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { CourseWithPosition } from '@/pages/Course/Course.type';
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
 import treeImage from '@/assets/tree.png';
-import { useDebounce } from '../_common/useDebounce';
 
 const { kakao } = window;
 
 const DEFAULT_ZOOM_LEVEL = 3;
-const DEBOUNCE_DELAY = 500;
 
 const MARKER_IMAGE: Record<string, string> = {
   TREE_01: treeImage,
@@ -17,10 +15,6 @@ const useTreeMap = () => {
   const mapRef = useRef<HTMLDivElement | null>(null);
 
   const [map, setMap] = useState<typeof kakao | null>(null);
-  const [currentPosition, setCurrentPosition] = useState({
-    latitude: DEFAULT_LATITUDE,
-    longitude: DEFAULT_LONGITUDE,
-  });
   const [centerPosition, setCenterPosition] = useState({
     latitude: DEFAULT_LATITUDE,
     longitude: DEFAULT_LONGITUDE,
@@ -28,8 +22,6 @@ const useTreeMap = () => {
 
   const [currentAddress, setCurrentAddress] = useState('');
   const [searchedPlaceList, setSearchedPlaceList] = useState<CourseWithPosition[]>([]);
-
-  const debouncedCenter = useDebounce(centerPosition, DEBOUNCE_DELAY);
 
   const MARKER_SIZE = new kakao.maps.Size(50, 55);
   const MARKER_OPTIONS = { offset: new kakao.maps.Point(25, 55) };
@@ -106,19 +98,15 @@ const useTreeMap = () => {
   useEffect(() => {
     if (!map) return;
 
-    kakao.maps.event.addListener(map, 'center_changed', handleCenterChanged);
-    return () => kakao.maps.event.removeListener(map, 'center_changed', handleCenterChanged);
+    kakao.maps.event.addListener(map, 'dragend', handleCenterChanged);
+    return () => kakao.maps.event.removeListener(map, 'dragend', handleCenterChanged);
   }, [map]);
-
-  useEffect(() => {
-    setCurrentPosition(debouncedCenter);
-  }, [debouncedCenter]);
 
   return {
     map,
     mapRef,
     currentAddress,
-    currentPosition,
+    centerPosition,
     addMarker,
     getAddress,
     searchPlaces,

--- a/frontend/src/pages/Course/CourseMain/CourseMain.tsx
+++ b/frontend/src/pages/Course/CourseMain/CourseMain.tsx
@@ -11,6 +11,8 @@ import { extractAddressPart } from '@/utils/extractAddressPart';
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
 import * as S from './CourseMain.css';
 
+const DEBOUNCE_DELAY = 200;
+
 const CourseMain = () => {
   const [currentPosition, setCurrentPosition] = useState<{
     latitude: number;
@@ -20,7 +22,7 @@ const CourseMain = () => {
     longitude: DEFAULT_LONGITUDE,
   });
   const [inputValue, setInputValue] = useState('');
-  const debouncedInputValue = useDebounce(inputValue, 200);
+  const debouncedInputValue = useDebounce(inputValue, DEBOUNCE_DELAY);
 
   const navigate = useNavigate();
 
@@ -34,7 +36,7 @@ const CourseMain = () => {
     const selectedPlace = searchedPlaceList.find((place) => place.place_name === data);
     if (!selectedPlace) return;
 
-    navigate(`/course/detail?keyword=${inputValue}&latitude=${selectedPlace.x}&longitude=${selectedPlace.y}`);
+    navigate(`/course/detail?keyword=${data}&latitude=${selectedPlace.y}&longitude=${selectedPlace.x}`);
   };
 
   useEffect(() => {

--- a/frontend/src/pages/TreeMap/TreeMap.tsx
+++ b/frontend/src/pages/TreeMap/TreeMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import FloatingButton from '@/components/_common/FloatingButton/FloatingButton';
 import Modal from '@/components/_common/Modal/Modal';
@@ -6,28 +6,15 @@ import useModal from '@/hooks/_common/useModal';
 import useModalContent from '@/hooks/TreeMap/useModalContent';
 import useTreeMap from '@/hooks/TreeMap/useTreeMap';
 import useTreesQuery from '@/queries/Tree/useTreesQuery';
-import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
 import * as S from './TreeMap.css';
 
 const TreeMap = () => {
-  const [currentPosition, setCurrentPosition] = useState({
-    latitude: DEFAULT_LATITUDE,
-    longitude: DEFAULT_LONGITUDE,
-  });
-
-  useEffect(() => {
-    navigator.geolocation.getCurrentPosition((position) => {
-      setCurrentPosition({ latitude: position.coords.latitude, longitude: position.coords.longitude });
-    });
-  }, []);
-
   const location = useLocation();
   const navigate = useNavigate();
 
   const { isModalOpen, openModal, closeModal } = useModal();
-  const { map, mapRef, addMarker } = useTreeMap();
+  const { map, mapRef, addMarker, currentPosition } = useTreeMap();
   const { trees, isSuccess } = useTreesQuery(currentPosition);
-
   const handleMarkerClick = (treeId: number) => {
     openModal();
     navigate(`/map/${treeId}?modal=feeds`);

--- a/frontend/src/pages/TreeMap/TreeMap.tsx
+++ b/frontend/src/pages/TreeMap/TreeMap.tsx
@@ -13,8 +13,8 @@ const TreeMap = () => {
   const navigate = useNavigate();
 
   const { isModalOpen, openModal, closeModal } = useModal();
-  const { map, mapRef, addMarker, currentPosition } = useTreeMap();
-  const { trees, isSuccess } = useTreesQuery(currentPosition);
+  const { map, mapRef, addMarker, centerPosition } = useTreeMap();
+  const { trees, isSuccess } = useTreesQuery(centerPosition);
   const handleMarkerClick = (treeId: number) => {
     openModal();
     navigate(`/map/${treeId}?modal=feeds`);
@@ -33,7 +33,7 @@ const TreeMap = () => {
   const modalContent = useModalContent(modalType);
 
   const handleButtonClick = () => {
-    navigate('/map?modal=submit', { state: { center: currentPosition } });
+    navigate('/map?modal=submit', { state: { center: centerPosition } });
   };
 
   useEffect(() => {

--- a/frontend/src/utils/validate.ts
+++ b/frontend/src/utils/validate.ts
@@ -1,3 +1,5 @@
+import { FEED } from '@/constants/feed';
+
 export const validatePassword = (password: string): boolean => {
   const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,16}$/;
 
@@ -5,7 +7,7 @@ export const validatePassword = (password: string): boolean => {
 };
 
 export const validateContent = (content: string): boolean => {
-  if (content.trim() === '') return false;
+  if (content.trim() === '' || content.length > FEED.contentMaxLength) return false;
 
   return true;
 };

--- a/frontend/src/utils/validate.ts
+++ b/frontend/src/utils/validate.ts
@@ -1,0 +1,11 @@
+export const validatePassword = (password: string): boolean => {
+  const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,16}$/;
+
+  return passwordRegex.test(password);
+};
+
+export const validateContent = (content: string): boolean => {
+  if (content.trim() === '') return false;
+
+  return true;
+};


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #90

## ✨ 구현한 기능

- [x] 피드 제출 시 사용자 입력값에 따라 밸리데이션 & 버튼 active
- [x] map에서 새로운 트리를 가져오지 않는 문제 해결
- [x] `FeedList`에서 아래 일부가 가려지는 CSS 문제 해결

## ✏️ 자세한 구현 내용

### 피드 제출 시 사용자 입력값에 따라 밸리데이션 & 버튼 active

- `useFeedSubmit` 훅에서 `isContentError`와 `isPasswordError`를 두어 에러 상태를 관리합니다.

- `isContentError` 유효성 검사
  - `content.trim()`이 공백인 경우 false

- `isPasswordError` 유효성 검사
  - `passwordRegex`를 통해 글자에 영문, 숫자가 모두 포함되지 않거나 8자~16자가 아닌 경우 false


### map에서 새로운 트리를 가져오지 않는 문제 해결

- 글을 제출하면서 새로운 트리를 생성해도 `TreeMap`에서 새롭게 생성된 트리가 보이지 않았는데요, 이를 해결하기 위해 `map`에  `dragend` (드래그) 이벤트가 발생하는 경우 드래그 종료 시점에 카카오맵으로부터 새로운 center값을 가져와 `centerPosition`을 업데이트 하도록 구현했습니다! 👉🏻 centerPosition이 바뀌면 변경된 주소로 `트리 리스트를 불러오는 API`를 호출하게 돼요.

```tsx
  const handleCenterChanged = useCallback(() => {
    if (map) {
      const center = map.getCenter();
      setCenterPosition({ latitude: center.getLat(), longitude: center.getLng() });
    }
  }, [map]);

  useEffect(() => {
    if (!map) return;

    kakao.maps.event.addListener(map, 'dragend', handleCenterChanged);
    return () => kakao.maps.event.removeListener(map, 'dragend', handleCenterChanged);
  }, [map]);
```

### `FeedList`에서 아래 일부가 가려지는 CSS 문제 해결
- FeedList 부분 확인하다 CSS가 가려지는 문제를 확인해서 조정했습니다.

- 변경 전
<img width="198" alt="image" src="https://github.com/user-attachments/assets/29ee7f90-a6a4-42cf-b5bf-3f76ec37e2de" />

- 변경 후
<img width="188" alt="image" src="https://github.com/user-attachments/assets/111fcd44-fe5a-4dd8-a23a-ac613f457060" />


## 🧐 질문하고 싶은 내용

<img width="257" alt="image" src="https://github.com/user-attachments/assets/d93e699c-29f4-499d-aaf4-d4c609b0e95e" />

- 현재는 Error 상태의 기본값을 `true`로 지정해놓아서 사용자가 처음 `Submit` 페이지에 진입하는 경우 위와 같이 에러 메시지가 떠 있는데요, 이대로 구현해도 괜찮을지, 아니면 사용자가 입력을 시작할 때 에러 메시지가 떠 있는 것이 나을지 파슬리의 의견이 궁금합니다!
