### PR TITLE
[FE] 상세 코스 지도 카드로 구현 Issue #98

### DIFF
--- a/frontend/src/components/Course/CourseMap/CourseMap.tsx
+++ b/frontend/src/components/Course/CourseMap/CourseMap.tsx
@@ -12,14 +12,13 @@ const { kakao } = window;
 interface CourseMapProps {
   courseList: CourseDetails;
   mapLevel?: number;
-  draggable?: boolean;
-  isClickableTooltip?: boolean;
+  isStaticMap?: boolean;
 }
 
-const CourseMap = ({ courseList, mapLevel, draggable, isClickableTooltip = true }: CourseMapProps) => {
-  const { map, mapRef, currentTooltipRef, addMarker } = useCourseMap({ courseList, mapLevel, draggable });
+const CourseMap = ({ courseList, mapLevel, isStaticMap = false }: CourseMapProps) => {
+  const { map, mapRef, currentTooltipRef, addMarker } = useCourseMap({ courseList, mapLevel, isStaticMap });
   const addTooltip = (map: any, type: CourseType, courseItem: Course) => {
-    const marker = addMarker(map, type, courseItem.y, courseItem.x, isClickableTooltip || false);
+    const marker = addMarker(map, type, courseItem.y, courseItem.x, !isStaticMap);
     const tooltipContainer = document.createElement('div');
     const root = createRoot(tooltipContainer);
 

--- a/frontend/src/components/Course/CourseMap/CourseMap.tsx
+++ b/frontend/src/components/Course/CourseMap/CourseMap.tsx
@@ -13,12 +13,13 @@ interface CourseMapProps {
   courseList: CourseDetails;
   mapLevel?: number;
   draggable?: boolean;
+  isClickableTooltip?: boolean;
 }
 
-const CourseMap = ({ courseList, mapLevel, draggable = true }: CourseMapProps) => {
+const CourseMap = ({ courseList, mapLevel, draggable, isClickableTooltip = true }: CourseMapProps) => {
   const { map, mapRef, currentTooltipRef, addMarker } = useCourseMap({ courseList, mapLevel, draggable });
   const addTooltip = (map: any, type: CourseType, courseItem: Course) => {
-    const marker = addMarker(map, type, courseItem.y, courseItem.x);
+    const marker = addMarker(map, type, courseItem.y, courseItem.x, isClickableTooltip || false);
     const tooltipContainer = document.createElement('div');
     const root = createRoot(tooltipContainer);
 

--- a/frontend/src/components/Course/CourseMap/CourseMap.tsx
+++ b/frontend/src/components/Course/CourseMap/CourseMap.tsx
@@ -11,11 +11,12 @@ const { kakao } = window;
 
 interface CourseMapProps {
   courseList: CourseDetails;
+  mapLevel?: number;
+  draggable?: boolean;
 }
 
-const CourseMap = ({ courseList }: CourseMapProps) => {
-  const { map, mapRef, currentTooltipRef, addMarker } = useCourseMap(courseList);
-
+const CourseMap = ({ courseList, mapLevel, draggable = true }: CourseMapProps) => {
+  const { map, mapRef, currentTooltipRef, addMarker } = useCourseMap({ courseList, mapLevel, draggable });
   const addTooltip = (map: any, type: CourseType, courseItem: Course) => {
     const marker = addMarker(map, type, courseItem.y, courseItem.x);
     const tooltipContainer = document.createElement('div');

--- a/frontend/src/hooks/Course/useCourseMap.ts
+++ b/frontend/src/hooks/Course/useCourseMap.ts
@@ -40,10 +40,10 @@ const useCourseMap = ({ courseList, mapLevel = 5, draggable = true }: UseCourseM
   const MARKER_SIZE = new kakao.maps.Size(36, 36);
   const MARKER_OPTIONS = { offset: new kakao.maps.Point(18, 36) };
 
-  const addMarker = (map: any, type: CourseType, latitude: string, longitude: string) => {
+  const addMarker = (map: any, type: CourseType, latitude: string, longitude: string, clickable: boolean) => {
     const markerPosition = new kakao.maps.LatLng(latitude, longitude);
     const markerImage = new kakao.maps.MarkerImage(COURSE_MARKER[type], MARKER_SIZE, MARKER_OPTIONS);
-    const marker = new kakao.maps.Marker({ position: markerPosition, image: markerImage, clickable: true });
+    const marker = new kakao.maps.Marker({ position: markerPosition, image: markerImage, clickable });
 
     marker.setMap(map);
 

--- a/frontend/src/hooks/Course/useCourseMap.ts
+++ b/frontend/src/hooks/Course/useCourseMap.ts
@@ -12,10 +12,10 @@ interface TooltipState {
 interface UseCourseMapProps {
   courseList: CourseDetails;
   mapLevel?: number;
-  draggable?: boolean;
+  isStaticMap?: boolean;
 }
 
-const useCourseMap = ({ courseList, mapLevel = 5, draggable = true }: UseCourseMapProps) => {
+const useCourseMap = ({ courseList, mapLevel = 5, isStaticMap = false }: UseCourseMapProps) => {
   const mapRef = useRef<HTMLDivElement | null>(null);
   const currentTooltipRef = useRef<TooltipState | null>(null);
 
@@ -31,7 +31,12 @@ const useCourseMap = ({ courseList, mapLevel = 5, draggable = true }: UseCourseM
     const latitude = courses.reduce((acc: number, cur: Course) => (acc += Number(cur.y)), 0) / courses.length;
     const longitude = courses.reduce((acc: number, cur: Course) => (acc += Number(cur.x)), 0) / courses.length;
     if (mapRef.current && kakao && kakao.maps) {
-      const options = { center: new kakao.maps.LatLng(latitude, longitude), level: mapLevel, draggable };
+      const options = {
+        center: new kakao.maps.LatLng(latitude, longitude),
+        level: mapLevel,
+        draggable: !isStaticMap,
+        disableDoubleClick: isStaticMap,
+      };
       const map = new kakao.maps.Map(mapRef.current, options);
       setMap(map);
     }

--- a/frontend/src/hooks/Course/useCourseMap.ts
+++ b/frontend/src/hooks/Course/useCourseMap.ts
@@ -9,7 +9,13 @@ interface TooltipState {
   overlay: any;
 }
 
-const useCourseMap = (courseList: CourseDetails) => {
+interface UseCourseMapProps {
+  courseList: CourseDetails;
+  mapLevel?: number;
+  draggable?: boolean;
+}
+
+const useCourseMap = ({ courseList, mapLevel = 5, draggable = true }: UseCourseMapProps) => {
   const mapRef = useRef<HTMLDivElement | null>(null);
   const currentTooltipRef = useRef<TooltipState | null>(null);
 
@@ -17,11 +23,15 @@ const useCourseMap = (courseList: CourseDetails) => {
 
   const initializeMap = () => {
     const courses = Object.values(courseList);
+
+    if (courses.every((course) => course === null)) {
+      return;
+    }
+
     const latitude = courses.reduce((acc: number, cur: Course) => (acc += Number(cur.y)), 0) / courses.length;
     const longitude = courses.reduce((acc: number, cur: Course) => (acc += Number(cur.x)), 0) / courses.length;
-
     if (mapRef.current && kakao && kakao.maps) {
-      const options = { center: new kakao.maps.LatLng(latitude, longitude), level: 5 };
+      const options = { center: new kakao.maps.LatLng(latitude, longitude), level: mapLevel, draggable };
       const map = new kakao.maps.Map(mapRef.current, options);
       setMap(map);
     }
@@ -42,7 +52,7 @@ const useCourseMap = (courseList: CourseDetails) => {
 
   useEffect(() => {
     initializeMap();
-  }, []);
+  }, [courseList]);
 
   return { map, mapRef, currentTooltipRef, addMarker };
 };

--- a/frontend/src/pages/Course/CourseDetail/CourseDetail.css.ts
+++ b/frontend/src/pages/Course/CourseDetail/CourseDetail.css.ts
@@ -10,13 +10,27 @@ export const Title = style({
 });
 
 export const MapContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '10px',
+
   width: '100%',
   height: '180px',
   marginTop: '10px',
   marginBottom: '32px',
+  padding: '10px 22px',
   borderRadius: '15px',
 
   backgroundColor: vars.colors.secondary[50],
+});
+
+export const CourseMapContainer = style({
+  width: '100%',
+  height: '100%',
+  borderRadius: '15px',
+  overflow: 'hidden',
 });
 
 export const RefreshButton = style({

--- a/frontend/src/pages/Course/CourseDetail/CourseDetail.css.ts
+++ b/frontend/src/pages/Course/CourseDetail/CourseDetail.css.ts
@@ -57,3 +57,7 @@ export const RefreshButton = style({
 export const RefreshText = style({
   paddingTop: '2px',
 });
+
+export const DetailButton = style({
+  color: vars.colors.grey[500],
+});

--- a/frontend/src/pages/Course/CourseDetail/CourseDetail.tsx
+++ b/frontend/src/pages/Course/CourseDetail/CourseDetail.tsx
@@ -29,11 +29,11 @@ const CourseDetail = () => {
     <div className={S.Layout}>
       <h1 className={S.Title}>{keyword} 맞춤 코스 ✨</h1>
       <div className={S.MapContainer}>
-        <button type="button" onClick={() => setIsMapOpen(true)}>
+        <button className={S.DetailButton} type="button" onClick={() => setIsMapOpen(true)}>
           자세히 보기
         </button>
         <div className={S.CourseMapContainer}>
-          <CourseMap courseList={courseDetails} mapLevel={7} draggable={false} />
+          <CourseMap courseList={courseDetails} mapLevel={7} draggable={false} isClickableTooltip={false} />
         </div>
       </div>
       <CourseList courseList={courseDetails} />

--- a/frontend/src/pages/Course/CourseDetail/CourseDetail.tsx
+++ b/frontend/src/pages/Course/CourseDetail/CourseDetail.tsx
@@ -32,6 +32,9 @@ const CourseDetail = () => {
         <button type="button" onClick={() => setIsMapOpen(true)}>
           자세히 보기
         </button>
+        <div className={S.CourseMapContainer}>
+          <CourseMap courseList={courseDetails} mapLevel={7} draggable={false} />
+        </div>
       </div>
       <CourseList courseList={courseDetails} />
       {isButtonOpen && (

--- a/frontend/src/pages/Course/CourseDetail/CourseDetail.tsx
+++ b/frontend/src/pages/Course/CourseDetail/CourseDetail.tsx
@@ -33,7 +33,7 @@ const CourseDetail = () => {
           자세히 보기
         </button>
         <div className={S.CourseMapContainer}>
-          <CourseMap courseList={courseDetails} mapLevel={7} draggable={false} isClickableTooltip={false} />
+          <CourseMap courseList={courseDetails} mapLevel={7} isStaticMap={true} />
         </div>
       </div>
       <CourseList courseList={courseDetails} />


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #98

## ✨ 구현한 기능

- [x] 지도 카드 구현
- [x] `CourseDetail` 페이지에서 새로고침 시 발생하는 에러 해결

## ✏️ 자세한 구현 내용

### 지도 카드 구현

<img width="257" alt="image" src="https://github.com/user-attachments/assets/a753a4ea-d73e-414d-91b2-b725105a2593" />

- `isStaticMap` 옵션을 주어 드래그와 확대/축소 옵션을 선택할 수 있도록 했습니다.
- 지도 레벨 `mapLevel`을 추가했습니다.

```tsx
<CourseMap courseList={courseDetails} mapLevel={7} isStaticMap={true} />
```

###  `CourseDetail` 페이지에서 새로고침 시 발생하는 에러 해결

`CourseDetail` 페이지에서 새로고침을 하는 경우 `getCourseDetails`로부터 `courseDetail`가 null인 객체가 오더라구요..! 예상으로는 `searchParams`를 통해 위도&경도를 가져올 때 초기값이 `null`이 될 수도 있어서 그런 것 같아요. 그래서 `map`을 초기화 할 때 `if` 조건문을 통해 모든 값이 `null`이면 return하고, `useEffect` 의존성 배열에 `courseList`를 추가했습니다!

```tsx
const initializeMap = () => {
    const courses = Object.values(courseList);

    if (courses.every((course) => course === null)) {
      return;
    }

    const latitude = courses.reduce((acc: number, cur: Course) => (acc += Number(cur.y)), 0) / courses.length;
    const longitude = courses.reduce((acc: number, cur: Course) => (acc += Number(cur.x)), 0) / courses.length;
    if (mapRef.current && kakao && kakao.maps) {
      const options = {
        center: new kakao.maps.LatLng(latitude, longitude),
        level: mapLevel,
        draggable: !isStaticMap,
        disableDoubleClick: isStaticMap,
      };
      const map = new kakao.maps.Map(mapRef.current, options);
      setMap(map);
    }
  };

  useEffect(() => {
    initializeMap();
  }, [courseList]);
```

## 🧐 질문하고 싶은 내용

`isStaticMap` 옵션을 추가하는 방법 말고 더 좋은 방법이 있다면 적극 환영입니닷