### PR TITLE
[BE] 트리 GET 요청 시 현재 위치와 가까운 순서대로 정렬해서 반환 Issue #101

### DIFF
--- a/backend/src/main/java/com/christmas/tree/repository/TreeRepository.java
+++ b/backend/src/main/java/com/christmas/tree/repository/TreeRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface TreeRepository extends JpaRepository<TreeEntity, Long> {
 
-    @Query(value = "SELECT t FROM TreeEntity AS t WHERE ST_CONTAINS(ST_BUFFER(:location, :range), t.location)")
-    List<TreeEntity> findByLocationInRange(@Param("location") Point location, @Param("range") int range);
+    @Query(value = "SELECT t FROM TreeEntity AS t " +
+                   "WHERE ST_CONTAINS(ST_BUFFER(:location, :range), t.location)" +
+                   "ORDER BY ST_DISTANCE(t.location, :location) ASC")
+    List<TreeEntity> findByLocationInRangeOrderByAsc(@Param("location") Point location, @Param("range") int range);
 }

--- a/backend/src/main/java/com/christmas/tree/service/TreeService.java
+++ b/backend/src/main/java/com/christmas/tree/service/TreeService.java
@@ -30,7 +30,7 @@ public class TreeService {
 
     public List<TreeGetResponse> getTreeByRange(final TreeGetRequest request) {
         final Point location = PointGenerator.generate(request.longitude(), request.latitude());
-        List<TreeEntity> trees = treeRepository.findByLocationInRange(location, SEARCH_RADIUS_KM);
+        final List<TreeEntity> trees = treeRepository.findByLocationInRangeOrderByAsc(location, SEARCH_RADIUS_KM);
         return trees.stream()
                 .map(tree -> {
                     final Point point = tree.getLocation();

--- a/backend/src/test/java/com/christmas/tree/service/TreeServiceTest.java
+++ b/backend/src/test/java/com/christmas/tree/service/TreeServiceTest.java
@@ -51,6 +51,31 @@ class TreeServiceTest {
         assertThat(actual).hasSize(1);
     }
 
+    @DisplayName("현재 위치와 가까운 순서대로 트리를 반환한다.")
+    @Test
+    void get_tree_order_by_asc() {
+        // given
+        final List<Double> nearest = List.of(126.978900190292, 37.57068050838813);
+        final List<Double> secondNearest = List.of(126.97762075424428, 37.5717389421641);
+        final List<Double> thirdNearest = List.of(126.98022692200705, 37.572557060470906);
+        final List<List<Double>> treesByOrder = List.of(nearest, secondNearest, thirdNearest);
+        for (List<Double> trees : treesByOrder) {
+            createTree(trees.get(0), trees.get(1));
+        }
+        final Double nowX = 126.97790401142962;
+        final Double nowY = 37.57085151524508;
+        final TreeGetRequest request = new TreeGetRequest(nowX, nowY);
+
+        // when
+        final List<TreeGetResponse> actual = treeService.getTreeByRange(request);
+        final List<List<Double>> actualTrees = actual.stream()
+                .map(response -> List.of(response.longitude(), response.latitude()))
+                .toList();
+
+        // then
+        assertThat(actualTrees).containsExactlyElementsOf(treesByOrder);
+    }
+
     private void createTree(final Double longitude, final Double latitude) {
         final TreeCreateRequest treeCreateRequest = new TreeCreateRequest(longitude, latitude, "test");
         treeService.createTree(treeCreateRequest);


### PR DESCRIPTION
## 📌 연관된 이슈

- closes: #101 

## ✨ 구현한 기능
- 트리 GET 요청 시 현재 위치와 가까운 순서대로 정렬

## ✏️ 자세한 구현 내용
- 기존 jpql에 `ORDER BY ST_DISTANCE(t.location, :location) ASC` 조건 추가
