### PR TITLE
[FE] 상단 영역 겹치는 디자인 이슈 해결 및 에러 바운더리 설정 Issue #103

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Layout from '@/pages/Layout/Layout';
 import MapMarkerSelector from '@/pages/MapMarkerSelector/MapMarkerSelector';
 import TreeMap from '@/pages/TreeMap/TreeMap';
 import FeedList from '@/components/Feed/FeedList/FeedList';
+import GlobalErrorBoundary from './pages/Error/ErrorBoundary/GlobalErrorBoundary';
 
 const App = () => {
   const router = createBrowserRouter(
@@ -16,13 +17,21 @@ const App = () => {
         children: [
           {
             path: '',
-            element: <Landing />,
+            element: (
+              <GlobalErrorBoundary>
+                <Landing />
+              </GlobalErrorBoundary>
+            ),
           },
         ],
       },
       {
         path: '/map',
-        element: <Layout />,
+        element: (
+          <GlobalErrorBoundary>
+            <Layout />
+          </GlobalErrorBoundary>
+        ),
         children: [
           {
             path: '',
@@ -42,7 +51,11 @@ const App = () => {
       },
       {
         path: '/course',
-        element: <Layout title="맞춤 코스 추천" backgroundColor="white" isSticky={true} />,
+        element: (
+          <GlobalErrorBoundary>
+            <Layout title="맞춤 코스 추천" backgroundColor="white" isSticky={true} />
+          </GlobalErrorBoundary>
+        ),
         children: [
           {
             path: '',

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,7 +42,7 @@ const App = () => {
       },
       {
         path: '/course',
-        element: <Layout title="맞춤 코스 추천" isSticky={true} />,
+        element: <Layout title="맞춤 코스 추천" backgroundColor="white" isSticky={true} />,
         children: [
           {
             path: '',

--- a/frontend/src/components/_common/Header/Header.css.ts
+++ b/frontend/src/components/_common/Header/Header.css.ts
@@ -24,7 +24,7 @@ export const Layout = styleVariants({
   white: [LayoutBase, { backgroundColor: vars.colors.white }],
 });
 
-export const Button = style({
+export const ButtonBase = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -35,7 +35,6 @@ export const Button = style({
 
   backgroundColor: vars.colors.white,
   color: vars.colors.grey[800],
-  filter: 'drop-shadow(0px 3px 3px #00000040)',
 
   transition: '0.2s all ease',
 
@@ -48,6 +47,11 @@ export const Button = style({
   ':active': {
     color: vars.colors.primary[800],
   },
+});
+
+export const Button = styleVariants({
+  transparent: [ButtonBase, { filter: 'drop-shadow(0px 3px 3px #00000040)' }],
+  white: [ButtonBase, { filter: 'none' }],
 });
 
 export const TitleText = style({

--- a/frontend/src/components/_common/Header/Header.css.ts
+++ b/frontend/src/components/_common/Header/Header.css.ts
@@ -1,7 +1,7 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
 
-export const Layout = style({
+const LayoutBase = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
@@ -17,6 +17,11 @@ export const Layout = style({
   maxWidth: '480px',
   height: '48px',
   padding: '0 16px',
+});
+
+export const Layout = styleVariants({
+  transparent: [LayoutBase, { backgroundColor: 'transparent' }],
+  white: [LayoutBase, { backgroundColor: vars.colors.white }],
 });
 
 export const Button = style({
@@ -46,5 +51,7 @@ export const Button = style({
 });
 
 export const TitleText = style({
+  flex: 1,
   font: vars.fonts.body,
+  textAlign: 'center',
 });

--- a/frontend/src/components/_common/Header/Header.stories.tsx
+++ b/frontend/src/components/_common/Header/Header.stories.tsx
@@ -6,6 +6,7 @@ const meta = {
   component: Header,
   parameters: {
     layout: 'fullscreen',
+    backgroundColor: 'transparent',
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof Header>;
@@ -13,10 +14,15 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof Header>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    backgroundColor: 'transparent',
+  },
+};
 
 export const Title: Story = {
   args: {
     title: '맞춤 코스 추천',
+    backgroundColor: 'transparent',
   },
 };

--- a/frontend/src/components/_common/Header/Header.tsx
+++ b/frontend/src/components/_common/Header/Header.tsx
@@ -1,24 +1,26 @@
 import { useNavigate } from 'react-router-dom';
 import { IoIosArrowBack } from '@react-icons/all-files/io/IoIosArrowBack';
-import { IoMdMenu } from '@react-icons/all-files/io/IoMdMenu';
+// import { IoMdMenu } from '@react-icons/all-files/io/IoMdMenu';
 import * as S from './Header.css';
 
 interface HeaderProp {
   title?: string;
+  backgroundColor: 'transparent' | 'white';
 }
 
-const Header = ({ title = '' }: HeaderProp) => {
+const Header = ({ title = '', backgroundColor }: HeaderProp) => {
   const navigate = useNavigate();
 
   return (
-    <header className={S.Layout}>
+    <header className={S.Layout[backgroundColor]}>
       <button className={S.Button} onClick={() => navigate(-1)}>
         <IoIosArrowBack />
       </button>
       <p className={S.TitleText}>{title}</p>
-      <button className={S.Button}>
+      {/* 아직 사용하지 않는 더보기 버튼 주석처리 */}
+      {/* <button className={S.Button}>
         <IoMdMenu />
-      </button>
+      </button> */}
     </header>
   );
 };

--- a/frontend/src/components/_common/Header/Header.tsx
+++ b/frontend/src/components/_common/Header/Header.tsx
@@ -13,7 +13,7 @@ const Header = ({ title = '', backgroundColor }: HeaderProp) => {
 
   return (
     <header className={S.Layout[backgroundColor]}>
-      <button className={S.Button} onClick={() => navigate(-1)}>
+      <button className={S.Button[backgroundColor]} onClick={() => navigate(-1)}>
         <IoIosArrowBack />
       </button>
       <p className={S.TitleText}>{title}</p>

--- a/frontend/src/pages/Course/CourseDetail/CourseDetail.css.ts
+++ b/frontend/src/pages/Course/CourseDetail/CourseDetail.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '@/styles/theme.css';
 
 export const Layout = style({
-  padding: '20px 16px',
+  padding: '48px 16px 20px',
 });
 
 export const Title = style({

--- a/frontend/src/pages/Layout/Layout.tsx
+++ b/frontend/src/pages/Layout/Layout.tsx
@@ -4,13 +4,14 @@ import NavBar from '@/components/_common/NavBar/NavBar';
 
 interface LayoutProps {
   title?: string;
+  backgroundColor?: 'transparent' | 'white';
   isSticky?: boolean;
 }
 
-const Layout = ({ title = '', isSticky = false }: LayoutProps) => {
+const Layout = ({ title = '', backgroundColor = 'transparent', isSticky = false }: LayoutProps) => {
   return (
     <>
-      <Header title={title} />
+      <Header title={title} backgroundColor={backgroundColor} />
       <Outlet />
       <NavBar isSticky={isSticky} />
     </>

--- a/frontend/src/pages/Layout/Layout.tsx
+++ b/frontend/src/pages/Layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import Header from '@/components/_common/Header/Header';
 import NavBar from '@/components/_common/NavBar/NavBar';
+import GlobalErrorBoundary from '../Error/ErrorBoundary/GlobalErrorBoundary';
 
 interface LayoutProps {
   title?: string;
@@ -10,11 +11,11 @@ interface LayoutProps {
 
 const Layout = ({ title = '', backgroundColor = 'transparent', isSticky = false }: LayoutProps) => {
   return (
-    <>
+    <GlobalErrorBoundary>
       <Header title={title} backgroundColor={backgroundColor} />
       <Outlet />
       <NavBar isSticky={isSticky} />
-    </>
+    </GlobalErrorBoundary>
   );
 };
 

--- a/frontend/src/pages/Layout/Layout.tsx
+++ b/frontend/src/pages/Layout/Layout.tsx
@@ -1,7 +1,6 @@
 import { Outlet } from 'react-router-dom';
 import Header from '@/components/_common/Header/Header';
 import NavBar from '@/components/_common/NavBar/NavBar';
-import GlobalErrorBoundary from '../Error/ErrorBoundary/GlobalErrorBoundary';
 
 interface LayoutProps {
   title?: string;
@@ -11,11 +10,11 @@ interface LayoutProps {
 
 const Layout = ({ title = '', backgroundColor = 'transparent', isSticky = false }: LayoutProps) => {
   return (
-    <GlobalErrorBoundary>
+    <>
       <Header title={title} backgroundColor={backgroundColor} />
       <Outlet />
       <NavBar isSticky={isSticky} />
-    </GlobalErrorBoundary>
+    </>
   );
 };
 


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #103

## ✨ 구현한 기능

1. 상단 영역 겹치는 디자인 이슈 해결
2. 전역 에러 바운더리 설정


## ✏️ 자세한 구현 내용

1. 상단 영역 겹치는 디자인 이슈 해결

- Header와 Layout에 backgroundColor props를 추가했어요. 기본값은 transparent이에요! (지도에서 투명한 배경으로 사용되고, 코스에서 흰색 배경으로 사용돼요.)
- 헤더에서 사용하지 않는 우측 햄버거 버튼을 주석처리했어요.

|개선 전|개선 후|
|---|---|
|<img src="https://github.com/user-attachments/assets/80d01b83-b9d7-4079-8624-1286dd7ed810" />|<img src="https://github.com/user-attachments/assets/09c4adea-5248-45b0-8283-22e8f297cbde"/>|




2. 전역 에러 바운더리 설정
- 전역 에러 바운더리가 라우팅 에러가 발생하는 경우에만 적용되어 있었어요. 모든 페이지의 기본 레이아웃인 Layout과 Landing에 GlobalErrorBoundary를 적용해 라우팅 에러나 컴포넌트 레벨의 에러가 아닌 전역에서 잡히는 에러는 GlobalErrorBoundary로 처리되도록 했어요!
- 모든 페이지들의 진입점에서 GlobalErrorBoundary를 감싸주었는데 (App.tsx) 더 좋은 위치가 있다면 의견 부탁드려욤🤗

