### PR TITLE
fix: useTreeMap의 MARKER_SIZE, MARKER_OPTIONS 위치를 addMarker 내부로 이동

### DIFF
--- a/frontend/src/hooks/TreeMap/useTreeMap.ts
+++ b/frontend/src/hooks/TreeMap/useTreeMap.ts
@@ -23,9 +23,6 @@ const useTreeMap = () => {
   const [currentAddress, setCurrentAddress] = useState('');
   const [searchedPlaceList, setSearchedPlaceList] = useState<CourseWithPosition[]>([]);
 
-  const MARKER_SIZE = new kakao.maps.Size(50, 55);
-  const MARKER_OPTIONS = { offset: new kakao.maps.Point(25, 55) };
-
   const initializeMap = (latitude: number, longitude: number) => {
     if (mapRef.current && kakao && kakao.maps) {
       const options = { center: new kakao.maps.LatLng(latitude, longitude), level: DEFAULT_ZOOM_LEVEL };
@@ -37,6 +34,9 @@ const useTreeMap = () => {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const addMarker = (map: any, latitude: number, longitude: number, imageCode: string, onClick?: () => void) => {
+    const MARKER_SIZE = new kakao.maps.Size(50, 55);
+    const MARKER_OPTIONS = { offset: new kakao.maps.Point(25, 55) };
+
     const markerPosition = new kakao.maps.LatLng(latitude, longitude);
     const markerImage = new kakao.maps.MarkerImage(MARKER_IMAGE[imageCode], MARKER_SIZE, MARKER_OPTIONS);
     const marker = new kakao.maps.Marker({ position: markerPosition, image: markerImage, clickable: true });


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #109 

## ✨ 구현한 기능

useTreeMap에 선언된 MARKER_SIZE와 MARKER_OPTIONS 오류를 대응해요.

## ✏️ 자세한 구현 내용

MARKER_SIZE와 MARKER_OPTIONS가 useTreeMap에 선언되어 있었는데, 카카오맵 인스턴스가 생성되기 전에 카카오맵을 호출하고 있었어요. 따라서 이 변수를 사용하고 있는 addMarker 내부로 위치를 옮겼어요.

![image](https://github.com/user-attachments/assets/090de155-e20b-42dd-ba9f-7416bb656896)


