### PR TITLE
[FE] dev CI workflow를 FE/dev에서만 실행하도록 변경 및 main 브랜치 CI 추가 Issue #112

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -1,0 +1,67 @@
+name: ✨ Frontend CI
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  FE_CI:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      actions: write
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    outputs:
+      lint: ${{ steps.yarn_lint_result.outputs.result }}
+      build: ${{ steps.yarn_build_result.outputs.result }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.15.1'
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        id: cache-deps
+        with:
+          path: ./frontend/node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run lint
+        id: yarn_lint
+        run: yarn lint
+
+      - name: Save Run lint result
+        id: yarn_lint_result
+        run: echo "result=${{steps.yarn_lint.outcome}}" >> $GITHUB_OUTPUT
+
+      - name: Run build
+        id: yarn_build
+        run: yarn build
+
+      - name: Save Run build result
+        id: yarn_build_result
+        run: echo "result=${{steps.yarn_build.outcome}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/frontend_dev_ci.yml
+++ b/.github/workflows/frontend_dev_ci.yml
@@ -3,6 +3,8 @@ name: ✨ Frontend Dev CI
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    branches:
+      - FE/dev
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #112 

## ✨ 구현한 기능

- dev 브랜치 CI와 main 브랜치 CI 분리
- main 브랜치 CI는 frontend 경로의 파일이 변경되는 경우 실행

## ✏️ 자세한 구현 내용

- dev 브랜치 CI가 main 브랜치에서도 동작했는데, 스토리북 배포가 포함되어 있어 파일을 나눴어요.
  - 스토리북 배포 시  `FE/dev`일 때만 실행되는 조건을 추가해도 되었지만 파일을 분리한 것은 각 CI의 역할이 다르다고 판단했기 때문이에요!
- main 브랜치의 CI는 백엔드 파일이나 다른 워크플로 파일 변경 시에는 동작하지 않도록 했어요.


