### PR TITLE
[BE] 피드 비밀번호 검증 api 추가 및 피드 수정 api 변경 #Issue 139

### DIFF
--- a/backend/src/main/java/com/christmas/feed/controller/FeedController.java
+++ b/backend/src/main/java/com/christmas/feed/controller/FeedController.java
@@ -1,5 +1,6 @@
 package com.christmas.feed.controller;
 
+import com.christmas.feed.dto.FeedVerifyRequest;
 import java.net.URI;
 import java.util.List;
 
@@ -51,11 +52,20 @@ public class FeedController implements FeedControllerDocs {
                 .body(likeCount);
     }
 
+
+
     @GetMapping("/feed")
     public ResponseEntity<List<FeedGetResponse>> getAllFeed(@RequestParam("treeId") long treeId) {
         List<FeedGetResponse> response = feedService.getAllFeedByTree(treeId);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(response);
+    }
+
+    @PostMapping("/feed/{id}/verify-password")
+    public ResponseEntity<Boolean> canUpdateFeed(@PathVariable("id") long id, @Valid @RequestBody FeedVerifyRequest request) {
+        final boolean canUpdateFeed = feedService.canUpdateFeed(id, request.password());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(canUpdateFeed);
     }
 
     @PatchMapping(

--- a/backend/src/main/java/com/christmas/feed/controller/FeedController.java
+++ b/backend/src/main/java/com/christmas/feed/controller/FeedController.java
@@ -74,8 +74,8 @@ public class FeedController implements FeedControllerDocs {
     )
     public ResponseEntity<FeedUpdateResponse> updateFeed(
             @PathVariable("id") long id,
-            @RequestPart("image") MultipartFile image,
-            @Valid @RequestPart("request") FeedUpdateRequest request
+            @RequestPart(value = "image", required = false) MultipartFile image,
+            @Valid @RequestPart(value = "request", required = false) FeedUpdateRequest request
     ) {
         FeedUpdateResponse response = feedService.updateFeed(id, image, request);
         return ResponseEntity.status(HttpStatus.OK)

--- a/backend/src/main/java/com/christmas/feed/dto/FeedUpdateRequest.java
+++ b/backend/src/main/java/com/christmas/feed/dto/FeedUpdateRequest.java
@@ -1,16 +1,10 @@
 package com.christmas.feed.dto;
 
-import jakarta.annotation.Nullable;
-import jakarta.validation.constraints.NotBlank;
-
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 
 @Schema(name = "피드 수정 요청")
 public record FeedUpdateRequest(
-        @Schema(description = "비밀번호")
-        @NotBlank(message = "비밀번호가 비어있습니다.")
-        String password,
-
         @Schema(description = "수정한 피드 내용. 수정을 했을 때만 값을 요청한다.", nullable = true)
         @Nullable
         String content

--- a/backend/src/main/java/com/christmas/feed/dto/FeedUpdateRequest.java
+++ b/backend/src/main/java/com/christmas/feed/dto/FeedUpdateRequest.java
@@ -1,12 +1,10 @@
 package com.christmas.feed.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Nullable;
 
 @Schema(name = "피드 수정 요청")
 public record FeedUpdateRequest(
-        @Schema(description = "수정한 피드 내용. 수정을 했을 때만 값을 요청한다.", nullable = true)
-        @Nullable
+        @Schema(description = "수정한 피드 내용. 수정을 했을 때만 입력한다.")
         String content
 ) {
 }

--- a/backend/src/main/java/com/christmas/feed/dto/FeedVerifyRequest.java
+++ b/backend/src/main/java/com/christmas/feed/dto/FeedVerifyRequest.java
@@ -1,0 +1,6 @@
+package com.christmas.feed.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FeedVerifyRequest(@NotBlank(message = "비밀번호가 공백입니다.") String password) {
+}

--- a/backend/src/main/java/com/christmas/feed/service/FeedService.java
+++ b/backend/src/main/java/com/christmas/feed/service/FeedService.java
@@ -1,18 +1,10 @@
 package com.christmas.feed.service;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.christmas.feed.domain.NicknameGenerator;
 import com.christmas.feed.dto.FeedCreateRequest;
 import com.christmas.feed.dto.FeedGetResponse;
 import com.christmas.feed.dto.FeedUpdateRequest;
+import com.christmas.feed.dto.FeedUpdateResponse;
 import com.christmas.feed.exception.InvalidPasswordException;
 import com.christmas.feed.exception.code.FeedErrorCode;
 import com.christmas.feed.repository.FeedImageFileRepository;
@@ -20,13 +12,18 @@ import com.christmas.feed.repository.FeedRepository;
 import com.christmas.feed.repository.entity.FeedEntity;
 import com.christmas.feed.repository.entity.FeedImageFileEntity;
 import com.christmas.feed.repository.entity.ImageFileEntity;
-import com.christmas.feed.dto.FeedUpdateResponse;
 import com.christmas.tree.exception.NotFoundTreeException;
 import com.christmas.tree.exception.code.TreeErrorCode;
 import com.christmas.tree.repository.TreeEntity;
 import com.christmas.tree.repository.TreeRepository;
-
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
 @RequiredArgsConstructor
@@ -106,9 +103,6 @@ public class FeedService {
                         FeedErrorCode.FEED_NOT_FOUND,
                         Map.of("id", String.valueOf(id)))
                 );
-        if (invalidPassword(feedEntity, request.password())) {
-            throw new InvalidPasswordException(FeedErrorCode.INVALID_PASSWORD, Map.of("password", request.password()));
-        }
         if (image != null) {
             FeedImageFileEntity feedImageFileEntity = feedImageFileRepository.findByFeedEntity(feedEntity);
             imageFileService.updateImage(feedImageFileEntity.getImageFileEntity(), image);
@@ -153,5 +147,15 @@ public class FeedService {
                 );
         feedEntity.removeLike();
         return feedEntity.getLikeCount();
+    }
+
+    public boolean canUpdateFeed(final long id, final String password) {
+        final FeedEntity feedEntity = feedRepository.findById(id)
+                .orElseThrow(() -> new NotFoundTreeException(
+                        FeedErrorCode.FEED_NOT_FOUND,
+                        Map.of("id", String.valueOf(id)))
+                );
+        return feedEntity.getPassword()
+                .equals(password);
     }
 }

--- a/backend/src/main/java/com/christmas/feed/service/FeedService.java
+++ b/backend/src/main/java/com/christmas/feed/service/FeedService.java
@@ -107,7 +107,7 @@ public class FeedService {
             FeedImageFileEntity feedImageFileEntity = feedImageFileRepository.findByFeedEntity(feedEntity);
             imageFileService.updateImage(feedImageFileEntity.getImageFileEntity(), image);
         }
-        if (request.content() != null) {
+        if (request != null) {
             feedEntity.updateContent(request.content());
         }
         ImageFileEntity imageFileEntity = feedImageFileRepository.findByFeedEntity(feedEntity)

--- a/backend/src/test/java/com/christmas/feed/service/FeedServiceTest.java
+++ b/backend/src/test/java/com/christmas/feed/service/FeedServiceTest.java
@@ -5,16 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.christmas.feed.dto.FeedCreateRequest;
 import com.christmas.feed.repository.FeedImageFileRepository;
 import com.christmas.feed.repository.FeedRepository;
@@ -24,6 +14,15 @@ import com.christmas.feed.repository.entity.ImageFileEntity;
 import com.christmas.tree.domain.PointGenerator;
 import com.christmas.tree.repository.TreeEntity;
 import com.christmas.tree.repository.TreeRepository;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
 @SpringBootTest
@@ -66,26 +65,47 @@ class FeedServiceTest {
         assertThat(feedImageFileRepository.findAll()).hasSize(1);
     }
 
-    @Test
     @Disabled
+    @Test
     @DisplayName("피드 생성 시 닉네임이 DB에 존재하면 닉네임 뒤에 중복 개수를 붙인다.")
     void create_duplicate_nickname() {
         // given
-        final TreeEntity treeEntity = treeRepository.save(
+        TreeEntity treeEntity = treeRepository.save(
                 new TreeEntity(PointGenerator.generate(127.2, 30.5), "IMAGE_CODE"));
         String nickname = "귀여운산타클로스";
-        int count = 2;
-        for (int i = 0; i < count; i++) {
-            feedRepository.save(new FeedEntity(treeEntity, nickname, "abcde123", "내용", 0L));
-        }
+        feedRepository.save(new FeedEntity(treeEntity, nickname, "abcde123", "내용", 0L));
         MultipartFile image = new MockMultipartFile("testImage", "content".getBytes());
         FeedCreateRequest request = new FeedCreateRequest(treeEntity.getId(), "피드 내용", "abc234!!");
-
+        ImageFileEntity imageFileEntity = imageFileRepository.save(new ImageFileEntity("test", "test", "test"));
+        when(imageFileService.createImage(any()))
+                .thenReturn(imageFileEntity);
+        // todo: 닉네임 제너레이터 인터페이스로 바꾸기
+        feedService.createFeed(request, image);
+        int count = 2;
 
         // when
         long feedId = feedService.createFeed(request, image);
+        FeedEntity feedEntity = feedRepository.findById(feedId)
+                .orElseThrow();
 
         // then
+        assertThat(feedEntity.getNickname()).isEqualTo(nickname + count);
+    }
 
+    @Test
+    @DisplayName("피드 비밀번호가 다르면 false를 반환한다.")
+    void verify_password() {
+        // given
+        TreeEntity treeEntity = treeRepository.save(new TreeEntity(PointGenerator.generate(127.2, 30.5), "IMAGE_CODE"));
+        String truePassword = "realpwd1234";
+        String falsePassword = "nonopwd!!";
+        FeedEntity feedEntity = new FeedEntity(treeEntity, "hoho", truePassword, "hi", 1L);
+        FeedEntity save = feedRepository.save(feedEntity);
+
+        // when
+        boolean isVerify = feedService.canUpdateFeed(save.getId(), falsePassword);
+
+        // then
+        assertThat(isVerify).isFalse();
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- closes: #139 

## ✨ 구현한 기능
- 피드 비밀번호 검증 api 추가
- 피드 수정 api에서 비밀번호 검증 로직 제거

