### PR TITLE
[FE] 코스 오류 해결 Issue #141

### DIFF
--- a/frontend/src/components/Course/CourseList/CourseList.tsx
+++ b/frontend/src/components/Course/CourseList/CourseList.tsx
@@ -31,7 +31,7 @@ const CourseList = ({ courseList }: CourseListProps) => {
                       <FaWalking size="15px" />
                     </div>
                   </div>
-                  걸어서 {value.pedestrian_route.duration_minutes}분
+                  걸어서 {value.pedestrian.duration_minutes}분
                 </div>
               )}
             </>

--- a/frontend/src/components/Course/CourseMap/CourseMap.tsx
+++ b/frontend/src/components/Course/CourseMap/CourseMap.tsx
@@ -64,7 +64,7 @@ const CourseMap = ({ courseList, mapLevel, isStaticMap = false }: CourseMapProps
 
         if (value) {
           addTooltip(map, type, value);
-          addPolyline(map, value.pedestrian_route.route);
+          addPolyline(map, value.pedestrian.route);
         }
       });
     }

--- a/frontend/src/mocks/data/courses.json
+++ b/frontend/src/mocks/data/courses.json
@@ -22,7 +22,7 @@
       },
       "total_count": 125
     },
-    "pedestrian_route": {
+    "pedestrian": {
       "duration_minutes": 15,
       "facility_type": {
         "횡단보도": 6
@@ -96,7 +96,7 @@
       },
       "total_count": 14
     },
-    "pedestrian_route": {
+    "pedestrian": {
       "duration_minutes": 16,
       "facility_type": {
         "횡단보도": 5
@@ -185,7 +185,7 @@
       },
       "total_count": 20
     },
-    "pedestrian_route": {
+    "pedestrian": {
       "duration_minutes": 28,
       "facility_type": {
         "횡단보도": 4
@@ -306,7 +306,7 @@
       },
       "total_count": 125
     },
-    "pedestrian_route": {
+    "pedestrian": {
       "duration_minutes": 24,
       "facility_type": {
         "횡단보도": 4

--- a/frontend/src/pages/Course/Course.type.ts
+++ b/frontend/src/pages/Course/Course.type.ts
@@ -14,7 +14,7 @@ export interface Course {
   road_address_name: string;
   x: string;
   y: string;
-  pedestrian_route: {
+  pedestrian: {
     duration_minutes: number;
     route: number[][];
   };


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #141

## ✨ 구현한 기능

코스 메뉴에서 발생하던 오류 해결

## ✏️ 자세한 구현 내용

써드 파티 라이브러리에서 지도 데이터를 받아오면서, 데이터 및 필드명을 의존해야 했어요.
최근 라이브러리 업데이트로 인해 필드명이 바뀌게 되었고 클라이언트에서 영향을 받아 에러가 발생했어요.

- 변경된 타입

```tsx
// 기존
export interface Course {
  id: string;
  phone: string;
  place_name: string;
  road_address_name: string;
  x: string;
  y: string;
  pedestrian_route: { // 이 부분이 pedestrian으로 변경됨
    duration_minutes: number;
    route: number[][];
  };
}
```

- `Course` 타입을 사용하는 곳의 `pedestrian_route`를 모두 `pedestrian`로 변경했어요

## 🧐 질문하고 싶은 내용

데이터를 가공하지 않고 그대로 사용하는 것이 맞는 것일까요.....?
