### PR TITLE
[BE] 피드 수정 시 트리 수정 제외 & 피드 단건 조회시 트리 위치 함께 반환 #Issue 146

### DIFF
--- a/backend/src/main/java/com/christmas/feed/dto/FeedGetResponse.java
+++ b/backend/src/main/java/com/christmas/feed/dto/FeedGetResponse.java
@@ -8,6 +8,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record FeedGetResponse(
         @Schema(description = "피드 id", example = "1")
         long id,
+        @Schema(description = "트리 경도", example = "127")
+        Double longitude,
+        @Schema(description = "트리 위도", example = "35")
+        Double latitude,
         @Schema(description = "피드 작성자 닉네임", example = "귀여운산타클로스")
         String nickname,
         @Schema(description = "피드 수정 시기", example = "2024-12-07T15:30:45.123")

--- a/backend/src/main/java/com/christmas/feed/dto/FeedUpdateRequest.java
+++ b/backend/src/main/java/com/christmas/feed/dto/FeedUpdateRequest.java
@@ -5,8 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "피드 수정 요청")
 public record FeedUpdateRequest(
         @Schema(description = "수정한 피드 내용. 수정을 했을 때만 입력한다.")
-        String content,
-        @Schema(description = "트리 Id. 수정을 했을 때만 입력한다.")
-        Long treeId
+        String content
 ) {
 }

--- a/backend/src/main/java/com/christmas/feed/dto/FeedUpdateResponse.java
+++ b/backend/src/main/java/com/christmas/feed/dto/FeedUpdateResponse.java
@@ -6,8 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record FeedUpdateResponse(
         @Schema(description = "피드 id")
         long id,
-        @Schema(description = "트리 id")
-        long treeId,
         @Schema(description = "피드에 삽입된 이미지", example = "크리스마스.jpg")
         String imageUrl,
         @Schema(description = "피드 내용")

--- a/backend/src/main/java/com/christmas/feed/service/FeedService.java
+++ b/backend/src/main/java/com/christmas/feed/service/FeedService.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -109,20 +110,10 @@ public class FeedService {
         if (image != null) {
             imageFileService.updateImage(imageFileEntity, image);
         }
-        if (request != null) {
-            if (request.content() != null) {
-                feedEntity.updateContent(request.content());
-            }
-            if (request.treeId() != null) {
-                TreeEntity treeEntity = treeRepository.findById(request.treeId())
-                        .orElseThrow(() -> new NotFoundTreeException(
-                                TreeErrorCode.TREE_NOT_FOUND,
-                                Map.of("tree id", String.valueOf(request.treeId())))
-                        );
-                feedEntity.updateTreeEntity(treeEntity);
-            }
+        if (request != null && request.content() != null) {
+            feedEntity.updateContent(request.content());
         }
-        return new FeedUpdateResponse(id, feedEntity.getTreeEntity().getId(), imageFileEntity.getImageUrl(), feedEntity.getContent());
+        return new FeedUpdateResponse(id, imageFileEntity.getImageUrl(), feedEntity.getContent());
     }
 
     private boolean invalidPassword(FeedEntity feedEntity, String password) {
@@ -177,7 +168,9 @@ public class FeedService {
                 );
         final ImageFileEntity imageFileEntity = feedImageFileRepository.findByFeedEntity(feedEntity)
                 .getImageFileEntity();
-        return new FeedGetResponse(id, feedEntity.getNickname(), feedEntity.getUpdatedAt(),
+        final Point location = feedEntity.getTreeEntity()
+                .getLocation();
+        return new FeedGetResponse(id, location.getX(), location.getY(), feedEntity.getNickname(), feedEntity.getUpdatedAt(),
                 imageFileEntity.getImageUrl(), feedEntity.getContent(), feedEntity.getLikeCount());
     }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- closes: #146 

## ✨ 구현한 기능
- 피드 수정 시 트리 수정 불가
- 피드 단건 조회 시 트리 위치 함께 반환


