### PR TITLE
[FE] 피드 수정 및 삭제 기능 추가 Issue #128

### DIFF
--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -1,6 +1,6 @@
 import requestAPI from './requestAPI';
 
-interface Feeds {
+interface Feed {
   id: number;
   treeImageCode: string;
   nickname: string;
@@ -11,25 +11,41 @@ interface Feeds {
 }
 
 export const getFeeds = async (treeId: number) => {
-  return await requestAPI.get<Feeds[]>('/feed', { treeId });
+  return await requestAPI.get<Feed[]>('/feed', { treeId });
 };
 
-interface PostFeedRequest {
+interface FormDataRequest {
   imageFile: File;
   treeId: number;
   content: string;
   password: string;
 }
 
-export const postFeed = async ({ imageFile, treeId, content, password }: PostFeedRequest) => {
+const createFormData = (data: FormDataRequest): FormData => {
   const formData = new FormData();
+  const { treeId, content, password, imageFile } = data;
   const value = { treeId, content, password };
   const blob = new Blob([JSON.stringify(value)], { type: 'application/json' });
 
   formData.append('image', imageFile);
   formData.append('request', blob);
 
+  return formData;
+};
+
+export const postFeed = async (data: FormDataRequest) => {
+  const formData = createFormData(data);
   await requestAPI.post('/feed', formData);
+};
+
+interface UpdateFeedRequest {
+  feedId: number;
+  data: FormDataRequest;
+}
+
+export const updateFeed = async ({ feedId, data }: UpdateFeedRequest) => {
+  const formData = createFormData(data);
+  await requestAPI.patch(`/feed/${feedId}`, formData);
 };
 
 interface PostLikeFeedRequest {

--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -1,8 +1,13 @@
 import { Feed } from '@/types/feed.type';
 import requestAPI from './requestAPI';
 
+interface GetFeedResponse extends Feed {
+  latitude: number;
+  longitude: number;
+}
+
 export const getFeed = async (feedId: string) => {
-  return await requestAPI.get<Feed>(`/feed/${feedId}`);
+  return await requestAPI.get<GetFeedResponse>(`/feed/${feedId}`);
 };
 
 export const getFeeds = async (treeId: number) => {

--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -63,3 +63,12 @@ interface DeleteLikeFeedRequest {
 export const deleteLikeFeed = async ({ feedId }: DeleteLikeFeedRequest) => {
   await requestAPI.delete(`/feed/${feedId}/like`);
 };
+
+interface PostFeedPasswordRequest {
+  feedId: number;
+  password: string;
+}
+
+export const postFeedPassword = async ({ feedId, password }: PostFeedPasswordRequest) => {
+  return await requestAPI.post<boolean>(`/feed/${feedId}/verify-password`, { password });
+};

--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -35,6 +35,7 @@ export const postFeed = async (data: FormDataRequest) => {
 
 interface UpdateFeedRequest {
   feedId: string;
+  treeId: string;
   imageFile: File | null;
   content: string;
 }

--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -48,6 +48,15 @@ export const updateFeed = async ({ feedId, data }: UpdateFeedRequest) => {
   await requestAPI.patch(`/feed/${feedId}`, formData);
 };
 
+interface DeleteFeedRequest {
+  feedId: number;
+  password: string;
+}
+
+export const deleteFeed = async ({ feedId, password }: DeleteFeedRequest) => {
+  return await requestAPI.delete<number>(`/feed/${feedId}`, { password });
+};
+
 interface PostLikeFeedRequest {
   feedId: number;
 }

--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -1,14 +1,9 @@
+import { Feed } from '@/types/feed.type';
 import requestAPI from './requestAPI';
 
-interface Feed {
-  id: number;
-  treeImageCode: string;
-  nickname: string;
-  updatedAt: string;
-  imageUrl: string;
-  content: string;
-  likeCount: number;
-}
+export const getFeed = async (feedId: string) => {
+  return await requestAPI.get<Feed>(`/feed/${feedId}`);
+};
 
 export const getFeeds = async (treeId: number) => {
   return await requestAPI.get<Feed[]>('/feed', { treeId });
@@ -39,12 +34,28 @@ export const postFeed = async (data: FormDataRequest) => {
 };
 
 interface UpdateFeedRequest {
-  feedId: number;
-  data: FormDataRequest;
+  feedId: string;
+  imageFile: File | null;
+  content: string;
 }
 
-export const updateFeed = async ({ feedId, data }: UpdateFeedRequest) => {
-  const formData = createFormData(data);
+export const updateFeed = async ({ feedId, imageFile, content }: UpdateFeedRequest) => {
+  if (!imageFile && !content) {
+    console.error('imageFile과 content가 없습니다.');
+    return;
+  }
+
+  const formData = new FormData();
+
+  if (imageFile) {
+    formData.append('image', imageFile);
+  }
+
+  const value = { content };
+  const blob = new Blob([JSON.stringify(value)], { type: 'application/json' });
+
+  formData.append('request', blob);
+
   await requestAPI.patch(`/feed/${feedId}`, formData);
 };
 

--- a/frontend/src/apis/requestAPI.ts
+++ b/frontend/src/apis/requestAPI.ts
@@ -67,8 +67,12 @@ const requestAPI = {
     return this.apiMethods<T>({ method: 'PATCH', endpoint, body, queryParams });
   },
 
-  delete<T>(endpoint: string, queryParams?: Record<string, string | number | boolean>): Promise<T> {
-    return this.apiMethods({ method: 'DELETE', endpoint, queryParams });
+  delete<T>(
+    endpoint: string,
+    body?: Record<string, any>,
+    queryParams?: Record<string, string | number | boolean>,
+  ): Promise<T> {
+    return this.apiMethods({ method: 'DELETE', endpoint, body, queryParams });
   },
 };
 

--- a/frontend/src/apis/requestAPI.ts
+++ b/frontend/src/apis/requestAPI.ts
@@ -67,7 +67,7 @@ const requestAPI = {
     return this.apiMethods<T>({ method: 'PATCH', endpoint, body, queryParams });
   },
 
-  delete(endpoint: string, queryParams?: Record<string, string | number | boolean>): Promise<void> {
+  delete<T>(endpoint: string, queryParams?: Record<string, string | number | boolean>): Promise<T> {
     return this.apiMethods({ method: 'DELETE', endpoint, queryParams });
   },
 };

--- a/frontend/src/components/Feed/FeedEdit/FeedEdit.css.ts
+++ b/frontend/src/components/Feed/FeedEdit/FeedEdit.css.ts
@@ -1,0 +1,86 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const Layout = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '20px',
+
+  width: '100%',
+  padding: '27px 12px',
+  borderRadius: '20px',
+
+  background: vars.colors.white,
+});
+
+export const SelectMarkerBox = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '10px',
+
+  padding: '15px 31px',
+  borderRadius: '10px',
+  border: `1px solid ${vars.colors.grey[400]}`,
+
+  background: vars.colors.white,
+});
+
+export const MapIconWrapper = style({
+  minWidth: '37px',
+  height: '44px',
+});
+
+export const MapIcon = style({
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+});
+
+export const SelectMarkerText = style({
+  fontSize: vars.fonts.tiny,
+  color: vars.colors.grey[700],
+
+  whiteSpace: 'pre-line',
+});
+
+export const ImageUploadBox = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+});
+
+export const UploadedImage = style({
+  width: '100%',
+  height: 'auto',
+  aspectRatio: '1',
+  objectFit: 'cover',
+
+  cursor: 'pointer',
+  borderRadius: '10px',
+  background: vars.colors.grey[50],
+});
+
+export const UploadBox = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '5px',
+
+  width: '100%',
+  height: '100%',
+  aspectRatio: '1',
+
+  cursor: 'pointer',
+  borderRadius: '10px',
+  background: vars.colors.grey[50],
+});
+
+export const LabelText = style({
+  font: vars.fonts.label,
+  color: vars.colors.grey[700],
+});
+
+export const ImageInput = style({
+  display: 'none',
+});

--- a/frontend/src/components/Feed/FeedEdit/FeedEdit.tsx
+++ b/frontend/src/components/Feed/FeedEdit/FeedEdit.tsx
@@ -57,9 +57,9 @@ const FeedEdit = ({ feedId, treeId }: FeedEditProps) => {
 
       <div className={S.ImageUploadBox}>
         <p className={S.LabelText}>이미지 업로드</p>
-        {imageUrl ? (
+        {imageUrl || feed?.imageUrl ? (
           <img
-            src={feed?.imageUrl ?? imageUrl}
+            src={imageUrl || feed?.imageUrl}
             className={S.UploadedImage}
             alt="업로드된 이미지"
             onClick={handleImageUploadClick}

--- a/frontend/src/components/Feed/FeedEdit/FeedEdit.tsx
+++ b/frontend/src/components/Feed/FeedEdit/FeedEdit.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+import { RiImageAddLine } from '@react-icons/all-files/ri/RiImageAddLine';
+import Button from '@/components/_common/Button/Button';
+import TextArea from '@/components/_common/TextArea/TextArea';
+import useFeedEdit from '@/hooks/Feed/useFeedEdit';
+import useImageUploader from '@/hooks/Feed/useImageUploader';
+import useTreeMap from '@/hooks/TreeMap/useTreeMap';
+import useFeedQuery from '@/queries/Feed/useFeedQuery';
+import { FEED } from '@/constants/feed';
+import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
+import mapIcon from '@/assets/map.png';
+import * as S from './FeedEdit.css';
+
+interface FeedEditProps {
+  feedId: string;
+  treeId: string;
+}
+
+const FeedEdit = ({ feedId, treeId }: FeedEditProps) => {
+  const location = useLocation();
+  const center: { latitude: number; longitude: number } = useMemo(
+    () =>
+      location.state?.center ?? {
+        latitude: DEFAULT_LATITUDE,
+        longitude: DEFAULT_LONGITUDE,
+      },
+    [location.state.center],
+  );
+
+  const { feed } = useFeedQuery(feedId);
+  const { getAddress, currentAddress } = useTreeMap();
+  const { imageUrl, fileInputRef, handleImageUploadClick, handleImageChange } = useImageUploader();
+  const { content, isContentError, handleContentChange, handleSubmit } = useFeedEdit({
+    feedId,
+    treeId,
+    initialImageFile: fileInputRef.current?.files?.[0] ?? null,
+    initialContent: feed?.content ?? '',
+  });
+
+  useEffect(() => {
+    getAddress(center.latitude, center.longitude);
+  }, [center, getAddress]);
+
+  return (
+    <form className={S.Layout} onSubmit={handleSubmit}>
+      <div className={S.SelectMarkerBox}>
+        <div className={S.MapIconWrapper}>
+          <img src={mapIcon} alt="Map Icon" className={S.MapIcon} />
+        </div>
+        <p className={S.SelectMarkerText}>
+          현재 트리 주소
+          <br />
+          {currentAddress}
+        </p>
+      </div>
+
+      <div className={S.ImageUploadBox}>
+        <p className={S.LabelText}>이미지 업로드</p>
+        {imageUrl ? (
+          <img
+            src={feed?.imageUrl ?? imageUrl}
+            className={S.UploadedImage}
+            alt="업로드된 이미지"
+            onClick={handleImageUploadClick}
+          />
+        ) : (
+          <div className={S.UploadBox} onClick={handleImageUploadClick}>
+            <RiImageAddLine size={39} />
+            <p className={S.LabelText}>첨부할 이미지를 선택해 주세요.</p>
+          </div>
+        )}
+        <input type="file" accept="image/*" onChange={handleImageChange} className={S.ImageInput} ref={fileInputRef} />
+      </div>
+
+      <TextArea
+        value={content}
+        onChange={handleContentChange}
+        status={isContentError ? 'error' : 'default'}
+        errorMessage="내용을 작성해 주세요."
+        maxLength={FEED.contentMaxLength}
+      >
+        <TextArea.Label label="설명" />
+      </TextArea>
+      <Button type="submit" color="primary" disabled={isContentError ? true : false}>
+        제출
+      </Button>
+    </form>
+  );
+};
+
+export default FeedEdit;

--- a/frontend/src/components/Feed/FeedEdit/FeedEdit.tsx
+++ b/frontend/src/components/Feed/FeedEdit/FeedEdit.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 import { RiImageAddLine } from '@react-icons/all-files/ri/RiImageAddLine';
 import Button from '@/components/_common/Button/Button';
 import TextArea from '@/components/_common/TextArea/TextArea';
@@ -18,16 +17,6 @@ interface FeedEditProps {
 }
 
 const FeedEdit = ({ feedId, treeId }: FeedEditProps) => {
-  const location = useLocation();
-  const center: { latitude: number; longitude: number } = useMemo(
-    () =>
-      location.state?.center ?? {
-        latitude: DEFAULT_LATITUDE,
-        longitude: DEFAULT_LONGITUDE,
-      },
-    [location.state.center],
-  );
-
   const { feed } = useFeedQuery(feedId);
   const { getAddress, currentAddress } = useTreeMap();
   const { imageUrl, fileInputRef, handleImageUploadClick, handleImageChange } = useImageUploader();
@@ -37,6 +26,12 @@ const FeedEdit = ({ feedId, treeId }: FeedEditProps) => {
     initialImageFile: fileInputRef.current?.files?.[0] ?? null,
     initialContent: feed?.content ?? '',
   });
+  const center: { latitude: number; longitude: number } = useMemo(() => {
+    return {
+      latitude: feed.latitude ?? DEFAULT_LATITUDE,
+      longitude: feed.longitude ?? DEFAULT_LONGITUDE,
+    };
+  }, [feed]);
 
   useEffect(() => {
     getAddress(center.latitude, center.longitude);

--- a/frontend/src/components/Feed/FeedEdit/FeedEditGuard.tsx
+++ b/frontend/src/components/Feed/FeedEdit/FeedEditGuard.tsx
@@ -5,10 +5,11 @@ import FeedEdit from './FeedEdit';
 const FeedEditGuard = () => {
   const location = useLocation();
   const feedId = location.state?.feedId;
+  const treeId = location.state?.treeId;
 
   return (
-    <RouteGuard condition={!feedId} redirectPath="/map">
-      <FeedEdit feedId={feedId} />
+    <RouteGuard condition={!feedId || !treeId} redirectPath="/map">
+      <FeedEdit feedId={feedId} treeId={treeId} />
     </RouteGuard>
   );
 };

--- a/frontend/src/components/Feed/FeedEdit/FeedEditGuard.tsx
+++ b/frontend/src/components/Feed/FeedEdit/FeedEditGuard.tsx
@@ -1,0 +1,16 @@
+import { useLocation } from 'react-router-dom';
+import RouteGuard from '@/components/_common/RouteGuard/RouteGuard';
+import FeedEdit from './FeedEdit';
+
+const FeedEditGuard = () => {
+  const location = useLocation();
+  const feedId = location.state?.feedId;
+
+  return (
+    <RouteGuard condition={!feedId} redirectPath="/map">
+      <FeedEdit feedId={feedId} />
+    </RouteGuard>
+  );
+};
+
+export default FeedEditGuard;

--- a/frontend/src/components/Feed/FeedItem/FeedItem.css.ts
+++ b/frontend/src/components/Feed/FeedItem/FeedItem.css.ts
@@ -21,7 +21,7 @@ export const Header = style({
   width: '100%',
 });
 
-export const NicknameBox = style({
+export const HeaderLeft = style({
   display: 'flex',
   alignItems: 'center',
 });
@@ -40,6 +40,20 @@ export const BodyText = style({
 export const UpdatedAtText = style({
   font: vars.fonts.tiny,
   color: vars.colors.grey[500],
+});
+
+export const HeaderRight = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1px',
+
+  position: 'relative',
+});
+
+export const TooltipBox = style({
+  position: 'absolute',
+  top: '30px',
+  right: '1px',
 });
 
 export const Image = style({

--- a/frontend/src/components/Feed/FeedItem/FeedItem.tsx
+++ b/frontend/src/components/Feed/FeedItem/FeedItem.tsx
@@ -34,6 +34,12 @@ const FeedItem = ({ feed, treeId }: FeedItemProps) => {
         navigate(`/map/${treeId}?modal=password`, { state: { feedId: id } });
       },
     },
+    {
+      name: '삭제',
+      onClick: () => {
+        navigate(`/map/${treeId}?modal=password`, { state: { feedId: id, type: 'delete' } });
+      },
+    },
   ];
 
   const likedFeedList = JSON.parse(localStorage.getItem('liked_feeds') ?? '{}');

--- a/frontend/src/components/Feed/FeedItem/FeedItem.tsx
+++ b/frontend/src/components/Feed/FeedItem/FeedItem.tsx
@@ -31,7 +31,7 @@ const FeedItem = ({ feed, treeId }: FeedItemProps) => {
     {
       name: '수정',
       onClick: () => {
-        navigate(`/map/${treeId}?modal=password`);
+        navigate(`/map/${treeId}?modal=password`, { state: { feedId: id } });
       },
     },
   ];

--- a/frontend/src/components/Feed/FeedItem/FeedItem.tsx
+++ b/frontend/src/components/Feed/FeedItem/FeedItem.tsx
@@ -1,22 +1,40 @@
-import { useSearchParams } from 'react-router-dom';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { IoMdMore } from '@react-icons/all-files/io/IoMdMore';
 import HeartWithCount from '@/components/_common/HeartWithCount/HeartWithCount';
+import Tooltip from '@/components/_common/Tooltip/Tooltip';
+import { TooltipMenus } from '@/components/_common/Tooltip/Tooltip.type';
 import useFeedMutation from '@/queries/Feed/useFeedMutation';
 import { formatDateTime } from '@/utils/formatDateTime';
 import { manageLikedFeeds } from '@/utils/manageLikedFeeds';
 import { TREE_IMAGE } from '@/constants/feed';
+import { vars } from '@/styles/theme.css';
 import * as S from './FeedItem.css';
 import type { FeedItemType } from './FeedItem.type';
 
 interface FeedItemProps {
   feed: FeedItemType;
+  treeId: number;
 }
 
-const FeedItem = ({ feed }: FeedItemProps) => {
+const FeedItem = ({ feed, treeId }: FeedItemProps) => {
+  const navigate = useNavigate();
   const { id, nickname, updatedAt, imageUrl, likeCount, content, treeImageCode } = feed;
   const { addLikeFeedMutation, deleteLikeFeedMutation } = useFeedMutation();
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
-  const [searchParams] = useSearchParams();
-  const treeId = Number(searchParams.get('treeId'));
+  if (!treeId) {
+    throw new Error('treeId가 없습니다.');
+  }
+
+  const TOOLTIP_MENUS: TooltipMenus[] = [
+    {
+      name: '수정',
+      onClick: () => {
+        navigate(`/map/${treeId}?modal=password`);
+      },
+    },
+  ];
 
   const likedFeedList = JSON.parse(localStorage.getItem('liked_feeds') ?? '{}');
   const isSelected = likedFeedList[treeId] ? likedFeedList[treeId].includes(id) : false;
@@ -29,16 +47,27 @@ const FeedItem = ({ feed }: FeedItemProps) => {
     }
     manageLikedFeeds(treeId, id);
   };
-  console.log(treeImageCode);
+
+  const handleToggleTooltip = () => {
+    setIsTooltipOpen(!isTooltipOpen);
+  };
 
   return (
     <div className={S.Layout}>
       <div className={S.Header}>
-        <div className={S.NicknameBox}>
+        <div className={S.HeaderLeft}>
           <img src={TREE_IMAGE[treeImageCode as keyof typeof TREE_IMAGE]} className={S.TreeImage} />
           <p className={S.BodyText}>{nickname}</p>
         </div>
-        <p className={S.UpdatedAtText}>{formatDateTime(updatedAt)}</p>
+        <div className={S.HeaderRight}>
+          <p className={S.UpdatedAtText}>{formatDateTime(updatedAt)}</p>
+          <IoMdMore color={vars.colors.grey[500]} onClick={handleToggleTooltip} />
+          {isTooltipOpen && (
+            <div className={S.TooltipBox}>
+              <Tooltip menus={TOOLTIP_MENUS} />
+            </div>
+          )}
+        </div>
       </div>
       <img src={imageUrl} draggable={false} className={S.Image} alt="feed" />
       <HeartWithCount isSelected={isSelected} count={likeCount} onClickIcon={handleLiked} />

--- a/frontend/src/components/Feed/FeedList/FeedList.tsx
+++ b/frontend/src/components/Feed/FeedList/FeedList.tsx
@@ -6,16 +6,20 @@ import * as S from './FeedList.css';
 const FeedList = () => {
   const { treeId: treeIdParam } = useParams();
   const treeId = Number(treeIdParam);
-
+  
   if (!treeId) {
-    throw new Error();
+    throw new Error('treeId가 없습니다.');
   }
 
   const { feeds } = useFeedsQuery(treeId);
 
   return (
     <div className={S.Layout}>
-      {feeds && feeds.length > 0 ? feeds.map((feed) => <FeedItem key={feed.id} feed={feed} />) : <>피드가 없습니다.</>}
+      {feeds && feeds.length > 0 ? (
+        feeds.map((feed) => <FeedItem key={feed.id} feed={feed} treeId={treeId} />)
+      ) : (
+        <>피드가 없습니다.</>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.css.ts
+++ b/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.css.ts
@@ -1,0 +1,12 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const Layout = style({
+  padding: '35px 12px',
+  borderRadius: '20px',
+  background: vars.colors.white,
+});
+
+export const Divider = style({
+  height: '24px',
+});

--- a/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
+++ b/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
@@ -43,7 +43,7 @@ const FeedPasswordVerification = () => {
               break;
 
             default:
-              navigate(`/map?modal=edit`, { state: { treeId } });
+              navigate(`/map?modal=edit`, { state: { feedId, treeId } });
               break;
           }
         },

--- a/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
+++ b/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
@@ -9,15 +9,17 @@ const FeedPasswordVerification = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { treeId } = useParams();
-  const { postFeedPasswordMutation } = useFeedMutation();
+  const { postFeedPasswordMutation, deleteFeedMutation } = useFeedMutation();
   const [isError, setIsError] = useState(false);
+  const isDeleteType = location.state.type === 'delete';
+  const feedId = location.state.feedId;
 
   const handleInputChange = () => {
     setIsError(false);
   };
 
   const handlePasswordVerification = (password: string) => {
-    if (!location.state?.feedId) return;
+    if (!feedId) return;
 
     postFeedPasswordMutation(
       { feedId: location.state.feedId, password },
@@ -27,7 +29,23 @@ const FeedPasswordVerification = () => {
             setIsError(true);
             return;
           }
-          navigate(`/map?modal=submit`, { state: { treeId } });
+
+          switch (true) {
+            case isDeleteType:
+              deleteFeedMutation(
+                { feedId, password },
+                {
+                  onSuccess: () => {
+                    navigate(`/map/${treeId}?modal=feeds`);
+                  },
+                },
+              );
+              break;
+
+            default:
+              navigate(`/map?modal=edit`, { state: { treeId } });
+              break;
+          }
         },
         onError: () => setIsError(true),
       },

--- a/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
+++ b/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import Button from '@/components/_common/Button/Button';
+import Input from '@/components/_common/Input/Input';
+import * as S from './FeedPasswordVerification.css';
+
+const FeedPasswordVerification = () => {
+  const navigate = useNavigate();
+  const { treeId } = useParams();
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // 성공시 콜백
+    navigate(`/map?modal=submit`, { state: { treeId } });
+  };
+
+  return (
+    <div className={S.Layout}>
+      <form onSubmit={handleSubmit}>
+        <Input label="비밀번호를 입력해 주세요" type="password" />
+        <div className={S.Divider}></div>
+        <Button color="primary" type="submit">
+          입력하기
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default FeedPasswordVerification;

--- a/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
+++ b/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
@@ -1,30 +1,64 @@
-import React from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import Button from '@/components/_common/Button/Button';
 import Input from '@/components/_common/Input/Input';
+import useFeedMutation from '@/queries/Feed/useFeedMutation';
 import * as S from './FeedPasswordVerification.css';
 
 const FeedPasswordVerification = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { treeId } = useParams();
+  const { postFeedPasswordMutation } = useFeedMutation();
+  const [isError, setIsError] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    // 성공시 콜백
-    navigate(`/map?modal=submit`, { state: { treeId } });
+  const handleInputChange = () => {
+    setIsError(false);
   };
 
-  return (
-    <div className={S.Layout}>
-      <form onSubmit={handleSubmit}>
-        <Input label="비밀번호를 입력해 주세요" type="password" />
-        <div className={S.Divider}></div>
-        <Button color="primary" type="submit">
-          입력하기
-        </Button>
-      </form>
-    </div>
+  const handlePasswordVerification = (password: string) => {
+    if (!location.state?.feedId) return;
+
+    postFeedPasswordMutation(
+      { feedId: location.state.feedId, password },
+      {
+        onSuccess: (isValid: boolean) => {
+          if (!isValid) {
+            setIsError(true);
+            return;
+          }
+          navigate(`/map?modal=submit`, { state: { treeId } });
+        },
+        onError: () => setIsError(true),
+      },
+    );
+  };
+
+  const renderPasswordForm = () => (
+    <form
+      onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        const formData = new FormData(e.currentTarget);
+        const password = formData.get('password') as string;
+        handlePasswordVerification(password);
+      }}
+    >
+      <Input
+        name="password"
+        label="비밀번호를 입력해 주세요"
+        status={isError ? 'error' : 'default'}
+        errorMessage="비밀번호가 맞지 않습니다."
+        type="password"
+        onChange={handleInputChange}
+      />
+      <div className={S.Divider} />
+      <Button color="primary" type="submit">
+        입력하기
+      </Button>
+    </form>
   );
+
+  return <div className={S.Layout}>{renderPasswordForm()}</div>;
 };
 
 export default FeedPasswordVerification;

--- a/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
+++ b/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
@@ -32,8 +32,6 @@ const FeedSubmit = () => {
     location,
     navigate,
   });
-  const { treeId } = location.state;
-  console.log(treeId);
 
   useEffect(() => {
     getAddress(center.latitude, center.longitude);

--- a/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
+++ b/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
@@ -32,6 +32,8 @@ const FeedSubmit = () => {
     location,
     navigate,
   });
+  const { treeId } = location.state;
+  console.log(treeId);
 
   useEffect(() => {
     getAddress(center.latitude, center.longitude);

--- a/frontend/src/components/_common/RouteGuard/RouteGuard.tsx
+++ b/frontend/src/components/_common/RouteGuard/RouteGuard.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import useRedirect from '@/hooks/_common/useRedirect';
+
+interface RouteGuardProps {
+  condition: boolean;
+  redirectPath: string;
+}
+
+const RouteGuard = ({ condition, redirectPath, children }: React.PropsWithChildren<RouteGuardProps>) => {
+  const isRedirected = useRedirect({
+    condition,
+    redirectPath,
+  });
+
+  if (isRedirected) {
+    return null;
+  }
+
+  return <>{children}</>;
+};
+
+export default RouteGuard;

--- a/frontend/src/components/_common/Tooltip/Tooltip.css.ts
+++ b/frontend/src/components/_common/Tooltip/Tooltip.css.ts
@@ -1,0 +1,18 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const Layout = style({
+  display: 'flex',
+  flexDirection: 'column',
+
+  borderRadius: '4px',
+
+  backgroundColor: vars.colors.white,
+});
+
+export const menuText = style({
+  padding: '12px 16px',
+  font: vars.fonts.small,
+  color: vars.colors.grey[500],
+  cursor: 'pointer',
+});

--- a/frontend/src/components/_common/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/_common/Tooltip/Tooltip.tsx
@@ -1,0 +1,20 @@
+import * as S from './Tooltip.css';
+import { TooltipMenus } from './Tooltip.type';
+
+interface TooltipProps {
+  menus: TooltipMenus[];
+}
+
+const Tooltip = ({ menus }: TooltipProps) => {
+  return (
+    <div className={S.Layout}>
+      {menus.map((menu, index) => (
+        <button onClick={menu.onClick} key={index}>
+          <p className={S.menuText}>{menu.name}</p>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/frontend/src/components/_common/Tooltip/Tooltip.type.ts
+++ b/frontend/src/components/_common/Tooltip/Tooltip.type.ts
@@ -1,0 +1,4 @@
+export interface TooltipMenus {
+  name: string;
+  onClick: () => void;
+}

--- a/frontend/src/hooks/Feed/useFeedEdit.ts
+++ b/frontend/src/hooks/Feed/useFeedEdit.ts
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import useFeedMutation from '@/queries/Feed/useFeedMutation';
+import { validateContent } from '@/utils/validate';
+
+interface UseFeedEditProps {
+  feedId: string;
+  initialImageFile: File | null;
+  initialContent: string;
+}
+
+const useFeedEdit = ({ feedId, initialImageFile, initialContent }: UseFeedEditProps) => {
+  const imageFile = initialImageFile;
+  const [content, setContent] = useState(initialContent);
+  const [isContentError, setIsContentError] = useState(!content);
+
+  const { updateFeedMutation } = useFeedMutation();
+
+  const handleContentChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const content = event.target.value;
+
+    if (!validateContent(content)) {
+      setIsContentError(true);
+    } else {
+      setIsContentError(false);
+    }
+
+    setContent(content);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (isContentError) return;
+
+    // 수정 시 트리 id 고정, 위치도 변경되지 않음
+    await updateFeedMutation({
+      feedId,
+      imageFile,
+      content,
+    });
+  };
+
+  return {
+    content,
+    isContentError,
+    handleContentChange,
+    handleSubmit,
+  };
+};
+
+export default useFeedEdit;

--- a/frontend/src/hooks/Feed/useFeedEdit.ts
+++ b/frontend/src/hooks/Feed/useFeedEdit.ts
@@ -4,11 +4,12 @@ import { validateContent } from '@/utils/validate';
 
 interface UseFeedEditProps {
   feedId: string;
+  treeId: string;
   initialImageFile: File | null;
   initialContent: string;
 }
 
-const useFeedEdit = ({ feedId, initialImageFile, initialContent }: UseFeedEditProps) => {
+const useFeedEdit = ({ feedId, treeId, initialImageFile, initialContent }: UseFeedEditProps) => {
   const imageFile = initialImageFile;
   const [content, setContent] = useState(initialContent);
   const [isContentError, setIsContentError] = useState(!content);
@@ -35,6 +36,7 @@ const useFeedEdit = ({ feedId, initialImageFile, initialContent }: UseFeedEditPr
     // 수정 시 트리 id 고정, 위치도 변경되지 않음
     await updateFeedMutation({
       feedId,
+      treeId,
       imageFile,
       content,
     });

--- a/frontend/src/hooks/TreeMap/useModalContent.tsx
+++ b/frontend/src/hooks/TreeMap/useModalContent.tsx
@@ -1,4 +1,5 @@
 import FeedList from '@/components/Feed/FeedList/FeedList';
+import FeedPasswordVerification from '@/components/Feed/FeedPasswordVerification/FeedPasswordVerification';
 import FeedSubmit from '@/components/Feed/FeedSubmit/FeedSubmit';
 
 const useModalContent = (modalType: string | null) => {
@@ -7,6 +8,8 @@ const useModalContent = (modalType: string | null) => {
       return <FeedList />;
     case 'submit':
       return <FeedSubmit />;
+    case 'password':
+      return <FeedPasswordVerification />;
     default:
       return null;
   }

--- a/frontend/src/hooks/TreeMap/useModalContent.tsx
+++ b/frontend/src/hooks/TreeMap/useModalContent.tsx
@@ -1,3 +1,4 @@
+import FeedEditGuard from '@/components/Feed/FeedEdit/FeedEditGuard';
 import FeedList from '@/components/Feed/FeedList/FeedList';
 import FeedPasswordVerification from '@/components/Feed/FeedPasswordVerification/FeedPasswordVerification';
 import FeedSubmit from '@/components/Feed/FeedSubmit/FeedSubmit';
@@ -10,6 +11,8 @@ const useModalContent = (modalType: string | null) => {
       return <FeedSubmit />;
     case 'password':
       return <FeedPasswordVerification />;
+    case 'edit':
+      return <FeedEditGuard />;
     default:
       return null;
   }

--- a/frontend/src/hooks/_common/useRedirect.ts
+++ b/frontend/src/hooks/_common/useRedirect.ts
@@ -1,0 +1,19 @@
+import { useNavigate } from 'react-router-dom';
+
+interface RedirectOptions {
+  condition: boolean;
+  redirectPath: string;
+}
+
+const useRedirect = ({ condition, redirectPath }: RedirectOptions) => {
+  const navigate = useNavigate();
+
+  if (condition) {
+    navigate(redirectPath, { replace: true });
+    return true;
+  }
+
+  return false;
+};
+
+export default useRedirect;

--- a/frontend/src/mocks/handlers/feed.ts
+++ b/frontend/src/mocks/handlers/feed.ts
@@ -38,6 +38,48 @@ export const handlers = [
     }
   }),
 
+  http.patch(`${API_URL}/feed/:id`, async ({ request }) => {
+    try {
+      const url = new URL(request.url);
+      const feedId = Number(url.pathname.split('/').at(-1));
+
+      const formData = await request.formData();
+      const imageFile = formData.get('image') as File;
+      const requestData = formData.get('request');
+
+      if (!imageFile || !requestData) {
+        return HttpResponse.json({ message: '이미지와 요청 데이터가 필요합니다.' }, { status: 400 });
+      }
+      if (!feedId) {
+        return HttpResponse.json({ message: 'feedId가 없습니다.' }, { status: 400 });
+      }
+
+      const parsedRequest = JSON.parse(requestData as string);
+      const { content }: { content: string } = parsedRequest;
+
+      const previousFeed = mockFeeds.find((feed) => feed.id === feedId);
+
+      if (!previousFeed) {
+        return HttpResponse.json({ message: '피드를 찾을 수 없습니다.' }, { status: 404 });
+      }
+
+      const newFeed = {
+        ...previousFeed,
+        updatedAt: '2024-11-25T03:11:24.851Z',
+        content,
+      };
+
+      const feedIndex = mockFeeds.findIndex((feed) => feed.id === feedId);
+      mockFeeds[feedIndex] = newFeed;
+
+      return HttpResponse.json(newFeed.id);
+    } catch (error) {
+      console.error('MSW 핸들러 에러:', error);
+
+      return HttpResponse.json({ message: '서버 에러가 발생했습니다.' }, { status: 500 });
+    }
+  }),
+
   http.post(`${API_URL}/feed/:id/like`, async ({ request }) => {
     const url = new URL(request.url);
     const feedId = Number(url.pathname.split('/').at(-2));

--- a/frontend/src/mocks/handlers/feed.ts
+++ b/frontend/src/mocks/handlers/feed.ts
@@ -2,9 +2,12 @@ import { HttpResponse, http } from 'msw';
 import { API_URL } from '@/apis/requestAPI';
 import mockFeeds from '../data/feeds.json';
 
+// eslint-disable-next-line prefer-const
+let feeds = [...mockFeeds];
+
 export const handlers = [
   http.get(`${API_URL}/feed`, () => {
-    return HttpResponse.json(mockFeeds);
+    return HttpResponse.json(feeds);
   }),
 
   http.post(`${API_URL}/feed`, async ({ request }) => {
@@ -133,5 +136,12 @@ export const handlers = [
 
   http.post(`${API_URL}/feed/:feedId/verify-password`, async () => {
     return HttpResponse.json(true);
+  }),
+
+  http.delete(`${API_URL}/feed/:feedId`, async ({ request }) => {
+    const url = new URL(request.url);
+    const feedId = Number(url.pathname.split('/').at(-1));
+    feeds = feeds.filter((feed) => feed.id !== feedId);
+    return HttpResponse.json({ status: 200, feedId });
   }),
 ];

--- a/frontend/src/mocks/handlers/feed.ts
+++ b/frontend/src/mocks/handlers/feed.ts
@@ -130,4 +130,8 @@ export const handlers = [
     }
     return HttpResponse.json({ status: 200 });
   }),
+
+  http.post(`${API_URL}/feed/:feedId/verify-password`, async () => {
+    return HttpResponse.json(true);
+  }),
 ];

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -17,9 +17,9 @@ const useFeedMutation = () => {
 
   const { mutateAsync: updateFeedMutation } = useMutation({
     mutationFn: updateFeed,
-    onSuccess: (treeId) => {
+    onSuccess: (_, { treeId }) => {
       queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
-      // navigate(`/map/${treeId}?modal=feeds`);
+      navigate(`/map/${treeId}?modal=feeds`);
     },
   });
 

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -17,9 +17,8 @@ const useFeedMutation = () => {
 
   const { mutateAsync: updateFeedMutation } = useMutation({
     mutationFn: updateFeed,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS] });
-      // queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
+    onSuccess: (treeId) => {
+      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
       // navigate(`/map/${treeId}?modal=feeds`);
     },
   });

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { queryClient } from '@/main';
 import { useMutation } from '@tanstack/react-query';
-import { deleteLikeFeed, postFeed, postLikeFeed } from '@/apis/feed';
+import { deleteLikeFeed, postFeed, postLikeFeed, updateFeed } from '@/apis/feed';
 import { FEED_KEYS } from '../queryKeys';
 
 const useFeedMutation = () => {
@@ -12,6 +12,15 @@ const useFeedMutation = () => {
     onSuccess: (_, { treeId }) => {
       queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
       navigate(`/map/${treeId}?modal=feeds`);
+    },
+  });
+
+  const { mutateAsync: updateFeedMutation } = useMutation({
+    mutationFn: updateFeed,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS] });
+      // queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
+      // navigate(`/map/${treeId}?modal=feeds`);
     },
   });
 
@@ -29,7 +38,7 @@ const useFeedMutation = () => {
     },
   });
 
-  return { addFeedMutation, addLikeFeedMutation, deleteLikeFeedMutation };
+  return { addFeedMutation, updateFeedMutation, addLikeFeedMutation, deleteLikeFeedMutation };
 };
 
 export default useFeedMutation;

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -17,8 +17,9 @@ const useFeedMutation = () => {
 
   const { mutateAsync: updateFeedMutation } = useMutation({
     mutationFn: updateFeed,
-    onSuccess: (_, { treeId }) => {
+    onSuccess: (feedId, { treeId }) => {
       queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
+      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEED, { feedId }] });
       navigate(`/map/${treeId}?modal=feeds`);
     },
   });

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { queryClient } from '@/main';
 import { useMutation } from '@tanstack/react-query';
-import { deleteLikeFeed, postFeed, postFeedPassword, postLikeFeed, updateFeed } from '@/apis/feed';
+import { deleteFeed, deleteLikeFeed, postFeed, postFeedPassword, postLikeFeed, updateFeed } from '@/apis/feed';
 import { FEED_KEYS } from '../queryKeys';
 
 const useFeedMutation = () => {
@@ -33,8 +33,8 @@ const useFeedMutation = () => {
 
   const { mutate: deleteLikeFeedMutation } = useMutation({
     mutationFn: deleteLikeFeed,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS] });
+    onSuccess: (treeId) => {
+      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
     },
   });
 
@@ -42,7 +42,21 @@ const useFeedMutation = () => {
     mutationFn: postFeedPassword,
   });
 
-  return { addFeedMutation, updateFeedMutation, addLikeFeedMutation, deleteLikeFeedMutation, postFeedPasswordMutation };
+  const { mutate: deleteFeedMutation } = useMutation({
+    mutationFn: deleteFeed,
+    onSuccess: (treeId) => {
+      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
+    },
+  });
+
+  return {
+    addFeedMutation,
+    updateFeedMutation,
+    addLikeFeedMutation,
+    deleteLikeFeedMutation,
+    postFeedPasswordMutation,
+    deleteFeedMutation,
+  };
 };
 
 export default useFeedMutation;

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { queryClient } from '@/main';
 import { useMutation } from '@tanstack/react-query';
-import { deleteLikeFeed, postFeed, postLikeFeed, updateFeed } from '@/apis/feed';
+import { deleteLikeFeed, postFeed, postFeedPassword, postLikeFeed, updateFeed } from '@/apis/feed';
 import { FEED_KEYS } from '../queryKeys';
 
 const useFeedMutation = () => {
@@ -38,7 +38,11 @@ const useFeedMutation = () => {
     },
   });
 
-  return { addFeedMutation, updateFeedMutation, addLikeFeedMutation, deleteLikeFeedMutation };
+  const { mutate: postFeedPasswordMutation } = useMutation({
+    mutationFn: postFeedPassword,
+  });
+
+  return { addFeedMutation, updateFeedMutation, addLikeFeedMutation, deleteLikeFeedMutation, postFeedPasswordMutation };
 };
 
 export default useFeedMutation;

--- a/frontend/src/queries/Feed/useFeedQuery.ts
+++ b/frontend/src/queries/Feed/useFeedQuery.ts
@@ -1,0 +1,14 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getFeed } from '@/apis/feed';
+import { FEED_KEYS } from '@/queries/queryKeys';
+
+const useFeedQuery = (feedId: string) => {
+  const { data, ...rest } = useSuspenseQuery({
+    queryKey: [FEED_KEYS.FEED, { feedId }],
+    queryFn: () => getFeed(feedId),
+  });
+
+  return { feed: data, ...rest };
+};
+
+export default useFeedQuery;

--- a/frontend/src/queries/queryKeys.ts
+++ b/frontend/src/queries/queryKeys.ts
@@ -1,4 +1,5 @@
 export const FEED_KEYS = {
+  FEED: 'feed',
   FEEDS: 'feeds',
 };
 

--- a/frontend/src/types/feed.type.ts
+++ b/frontend/src/types/feed.type.ts
@@ -1,0 +1,9 @@
+export interface Feed {
+  id: number;
+  treeImageCode: string;
+  nickname: string;
+  updatedAt: string;
+  imageUrl: string;
+  content: string;
+  likeCount: number;
+}


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #128 

## ✨ 구현한 기능

- [x] 피드 수정/삭제 툴팁
- [x] 피드 수정
  - [x] 피드 수정 비밀번호 확인
  - [x] 피드 수정 페이지에서 내역 불러오기
  - [x] 수정된 피드 제출
  - [x] 피드 주소 기본값 세팅
- [x] 피드 삭제

## ✏️ 자세한 구현 내용

1. Feed 타입 추가
2. Tooltip 구현
3. 피드 비밀번호 검증 페이지 및 로직 추가
4. 피드 수정 페이지 추가
5. 피드 수정 시 개별 피드 불러오기 추가
- 개별 피드가 반드시 불러와져야 하기 때문에 항상 데이터가 있음을 보장하는 useSuspenseQuery 사용
6. RouteGuard 적용한 FeedEditGuard 추가
- 피드 수정 페이지에 url을 직접 입력하여 접근하는 것을 방지 (수정 페이지에서 feedId, treeId를 반드시 받아야 하기 때문)
7. 피드 삭제 구현
8. requestAPI의 delete 메서드에 body 추가
