### PR TITLE
[FE] 코스 에러 해결 Issue #162

### DIFF
--- a/frontend/src/pages/Course/CourseDetail/CourseDetail.tsx
+++ b/frontend/src/pages/Course/CourseDetail/CourseDetail.tsx
@@ -15,7 +15,7 @@ const CourseDetail = () => {
   const latitude = searchParams.get('latitude');
   const longitude = searchParams.get('longitude');
 
-  const { courseDetails, refetch } = useCourseDetailsQuery(latitude || '', longitude || '');
+  const { courseDetails, refetch, isLoading } = useCourseDetailsQuery(latitude || '', longitude || '');
 
   const [isMapOpen, setIsMapOpen] = useState(false);
   const [isButtonOpen, setIsButtonOpen] = useState(false);
@@ -36,7 +36,7 @@ const CourseDetail = () => {
           <CourseMap courseList={courseDetails} mapLevel={7} isStaticMap={true} />
         </div>
       </div>
-      <CourseList courseList={courseDetails} />
+      {!isLoading && <CourseList courseList={courseDetails} />}
       {isButtonOpen && (
         <button className={S.RefreshButton} onClick={() => refetch()}>
           <IoRefresh size="18px" color={vars.colors.secondary[700]} />

--- a/frontend/src/queries/Course/useCourseDetailsQuery.ts
+++ b/frontend/src/queries/Course/useCourseDetailsQuery.ts
@@ -4,12 +4,12 @@ import { COURSE_KEYS } from '@/queries/queryKeys';
 import { DEFAULT_COURSE_DETAILS } from '@/constants/course';
 
 const useCourseDetailsQuery = (latitude: string, longitude: string) => {
-  const { data, refetch } = useQuery({
+  const { data, refetch, isLoading } = useQuery({
     queryKey: [COURSE_KEYS.DETAIL, { latitude, longitude }],
     queryFn: () => getCourseDetails(latitude, longitude),
   });
 
-  return { courseDetails: data ?? DEFAULT_COURSE_DETAILS, refetch };
+  return { courseDetails: data ?? DEFAULT_COURSE_DETAILS, refetch, isLoading };
 };
 
 export default useCourseDetailsQuery;


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #162

## ✨ 구현한 기능

- 서버에서 courseList 응답이 오지 않은 상태 처리
- courseList 일부 프로퍼티가 null인 경우 처리

## ✏️ 자세한 구현 내용
### 서버에서 courseList 응답이 오지 않은 상태 처리
- 기존에는 isLoading을 사용하지 않고 useQuery로 courseList를 받아왔습니다. 이때 기본값은 DEFAULT_COURSE_DETAILS로 설정되어 있었어요.
```tsx
export const DEFAULT_COURSE_DETAILS: Record<CourseType, null> = {
  lunch: null,
  cafe: null,
  attraction: null,
  dinner: null,
};
```
- 하지만 데이터 응답을 받기 전 `CourseList` 컴포넌트에서 기본값으로 세팅된 courseList를 사용하게 되면서 courseList의 프로퍼티 값들이 undefined로 인식되는 에러가 발생했습니다.
- 그래서 useCourseDetailsQuery의 isLoading 상태를 기반으로 CourseList 컴포넌트를 렌더하여 서버에서 courseList 응답이 오지 않은 경우 CourseList 컴포넌트가 마운트되지 않도록 했습니다.

### useSuspenseQuery를 사용하지 않은 이유
- useSuspenseQuery는 항상 서버에서 응답받은 데이터를 반환한다는 특징이 있지만, 데이터 응답이 완료될 때까지 화면의 인터렉션이 멈춰있는 듯한 경험을 주게 됩니다. 즉, combobox에서 input을 제출해도 아무 반응이 일어나지 않게 되는 것이죠. 
- courseList를 호출하는 요청은 서버에서 지도 api를 추가로 호출해야 하는 작업이기 때문에 다른 api보다 시간이 오래 걸립니다. (평균 3.3초) 따라서 사용자 경험을 해치지 않기 위해서 isLoading 상태를 관리하고 추후 Suspense UI를 추가하는 방향으로 접근하면 좋을 것 같습니다.

### courseList 일부 프로퍼티가 null인 경우 처리

- useCourseList에서 courseList의 프로퍼티가 모두 null인 경우 얼리 리턴을 하고 있었는데, 일부 프로퍼티만 null로 응답받는 경우 에러가 발생했습니다. 얼리 리턴을 하는 if 조건문을 지나 latitude와 longitude를 구할 때 courses의 x, y 프로퍼티를 사용하고 있었기 때문입니다.
```tsx
const initializeMap = () => {
  const courses = Object.values(courseList);

  if (courses.every((course) => course === null)) {
    return;
  }

  const latitude = courses.reduce((acc: number, cur: Course) => (acc += Number(cur.y)), 0) / courses.length;
  const longitude = courses.reduce((acc: number, cur: Course) => (acc += Number(cur.x)), 0) / courses.length;

  // ...    
}
```

- 따라서 courseList를 null이 아닌 값들로 필터링하고, 필터링된 배열의 길이가 1 이상일 때만 map을 초기화하도록 했습니다.

