### PR TITLE
[FE] 에러바운더리 retry 개선

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import CourseDetail from '@/pages/Course/CourseDetail/CourseDetail';
 import CourseMain from '@/pages/Course/CourseMain/CourseMain';
-import GlobalErrorFallback from '@/pages/Error/GlobalErrorFallback/GlobalErrorFallback';
+import NotFoundPage from '@/pages/Error/NotFoundPage/NotFoundPage';
 import Landing from '@/pages/Landing/Landing';
 import Layout from '@/pages/Layout/Layout';
 import MapMarkerSelector from '@/pages/MapMarkerSelector/MapMarkerSelector';
@@ -67,7 +67,10 @@ const App = () => {
           },
         ],
       },
-      { path: '*', element: <GlobalErrorFallback statusCode={404} /> },
+      {
+        path: '*',
+        element: <NotFoundPage />,
+      },
     ],
     {
       future: {

--- a/frontend/src/hooks/_common/useDisplayedError.ts
+++ b/frontend/src/hooks/_common/useDisplayedError.ts
@@ -1,11 +1,9 @@
 import { useNavigate } from 'react-router-dom';
-import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import { displayErrorMessage } from '@/utils/displayErrorMessage';
 
-const useDisplayedError = (statusCode: number) => {
+const useDisplayedError = (statusCode: number, resetErrorBoundary: () => void) => {
   const errorMessage = displayErrorMessage(statusCode);
   const navigate = useNavigate();
-  const { reset } = useQueryErrorResetBoundary();
 
   const handleErrorButton = () => {
     switch (errorMessage.action) {
@@ -13,7 +11,7 @@ const useDisplayedError = (statusCode: number) => {
         navigate(-1);
         break;
       case 'retry':
-        reset();
+        resetErrorBoundary();
         break;
       case 'navigateHome':
         navigate('/');

--- a/frontend/src/pages/Error/ErrorBoundary/GlobalErrorBoundary.tsx
+++ b/frontend/src/pages/Error/ErrorBoundary/GlobalErrorBoundary.tsx
@@ -8,7 +8,9 @@ const GlobalErrorBoundary = ({ children }: React.PropsWithChildren) => {
   return (
     <ErrorBoundary
       onReset={reset}
-      fallbackRender={({ error }) => <GlobalErrorFallback statusCode={error.statusCode} />}
+      fallbackRender={({ error, resetErrorBoundary }) => (
+        <GlobalErrorFallback statusCode={error.statusCode} resetErrorBoundary={resetErrorBoundary} />
+      )}
     >
       {children}
     </ErrorBoundary>

--- a/frontend/src/pages/Error/ErrorBoundary/ModalErrorBoundary.tsx
+++ b/frontend/src/pages/Error/ErrorBoundary/ModalErrorBoundary.tsx
@@ -6,7 +6,12 @@ const ModalErrorBoundary = ({ children }: React.PropsWithChildren) => {
   const { reset } = useQueryErrorResetBoundary();
 
   return (
-    <ErrorBoundary onReset={reset} fallbackRender={({ error }) => <ModalErrorFallback statusCode={error.statusCode} />}>
+    <ErrorBoundary
+      onReset={reset}
+      fallbackRender={({ error, resetErrorBoundary }) => (
+        <ModalErrorFallback statusCode={error.statusCode} resetErrorBoundary={resetErrorBoundary} />
+      )}
+    >
       {children}
     </ErrorBoundary>
   );

--- a/frontend/src/pages/Error/GlobalErrorFallback/GlobalErrorFallback.stories.tsx
+++ b/frontend/src/pages/Error/GlobalErrorFallback/GlobalErrorFallback.stories.tsx
@@ -15,7 +15,9 @@ export default {
   },
 } as Meta;
 
-const Template: StoryFn<{ statusCode: number }> = (args) => <GlobalErrorFallback {...args} />;
+const Template: StoryFn<{ statusCode: number; resetErrorBoundary: () => void }> = (args) => (
+  <GlobalErrorFallback {...args} />
+);
 
 export const Default = Template.bind({});
 Default.args = {

--- a/frontend/src/pages/Error/GlobalErrorFallback/GlobalErrorFallback.tsx
+++ b/frontend/src/pages/Error/GlobalErrorFallback/GlobalErrorFallback.tsx
@@ -4,10 +4,11 @@ import * as S from './GlobalErrorFallback.css';
 
 interface GlobalErrorFallbackProps {
   statusCode: number;
+  resetErrorBoundary: () => void;
 }
 
-const GlobalErrorFallback = ({ statusCode }: GlobalErrorFallbackProps) => {
-  const { errorMessage, handleErrorButton } = useDisplayedError(statusCode);
+const GlobalErrorFallback = ({ statusCode, resetErrorBoundary }: GlobalErrorFallbackProps) => {
+  const { errorMessage, handleErrorButton } = useDisplayedError(statusCode, resetErrorBoundary);
 
   return (
     <div className={S.Layout}>

--- a/frontend/src/pages/Error/ModalErrorFallback/ModalErrorFallback.stories.tsx
+++ b/frontend/src/pages/Error/ModalErrorFallback/ModalErrorFallback.stories.tsx
@@ -21,7 +21,9 @@ export default {
   },
 } as Meta;
 
-const Template: StoryFn<{ statusCode: number }> = (args) => <ModalErrorFallback {...args} />;
+const Template: StoryFn<{ statusCode: number; resetErrorBoundary: () => void }> = (args) => (
+  <ModalErrorFallback {...args} />
+);
 
 export const Default = Template.bind({});
 Default.args = {

--- a/frontend/src/pages/Error/ModalErrorFallback/ModalErrorFallback.tsx
+++ b/frontend/src/pages/Error/ModalErrorFallback/ModalErrorFallback.tsx
@@ -4,10 +4,11 @@ import * as S from './ModalErrorFallback.css';
 
 interface ModalErrorFallbackProps {
   statusCode: number;
+  resetErrorBoundary: () => void;
 }
 
-const ModalErrorFallback = ({ statusCode }: ModalErrorFallbackProps) => {
-  const { errorMessage, handleErrorButton } = useDisplayedError(statusCode);
+const ModalErrorFallback = ({ statusCode, resetErrorBoundary }: ModalErrorFallbackProps) => {
+  const { errorMessage, handleErrorButton } = useDisplayedError(statusCode, resetErrorBoundary);
 
   return (
     <div className={S.Layout}>

--- a/frontend/src/pages/Error/NotFoundPage/NotFoundPage.css.ts
+++ b/frontend/src/pages/Error/NotFoundPage/NotFoundPage.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css';
+import { vars } from '@/styles/theme.css';
+
+export const Layout = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '20px',
+
+  width: '100%',
+  height: '100%',
+  padding: '40px 16px',
+});
+
+export const TitleText = style({
+  color: vars.colors.black,
+  fontSize: vars.fonts.body,
+  fontFamily: 'inherit',
+});

--- a/frontend/src/pages/Error/NotFoundPage/NotFoundPage.tsx
+++ b/frontend/src/pages/Error/NotFoundPage/NotFoundPage.tsx
@@ -1,0 +1,24 @@
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/_common/Button/Button';
+import { displayErrorMessage } from '@/utils/displayErrorMessage';
+import * as S from './NotFoundPage.css';
+
+const NotFoundPage = () => {
+  const navigate = useNavigate();
+  const errorMessage = displayErrorMessage(404);
+
+  const handleGoHome = () => {
+    navigate('/', { replace: true });
+  };
+
+  return (
+    <div className={S.Layout}>
+      <h1 className={S.TitleText}>{errorMessage.title}</h1>
+      <Button onClick={handleGoHome} color="primary">
+        홈으로 이동
+      </Button>
+    </div>
+  );
+};
+
+export default NotFoundPage;

--- a/frontend/src/utils/displayErrorMessage.ts
+++ b/frontend/src/utils/displayErrorMessage.ts
@@ -1,6 +1,6 @@
 import { ERROR_MESSAGE } from '@/constants/error';
 
-export const displayErrorMessage = (statusCode: number) => {
+export const displayErrorMessage = (statusCode?: number) => {
   switch (statusCode) {
     case 400:
       return { ...ERROR_MESSAGE.client, action: 'retry' };


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #165 

## ✨ 구현한 기능

- 에러 발생 시 재시도 버튼 동작이 안되는 현상 해결

## ✏️ 자세한 구현 내용

- 기존의 error boundary는 useQueryErrorResetBoundary로부터 reset 인자를 받아 쿼리의 에러 상태만 리셋하고 있었습니다. 하지만 이 방식은 재시도를 하는 것이 아닌, 단순히 쿼리의 상태만 초기화해주고 있던 것이었어요. (사실 reset을 넘겨주고 있던 `onReset`은 resetErrorBoundary가 실행되어야 onReset이 실행되었던 것이었습니다 ,, 뚜둥,,)
- 따라서 `ErrorBoundary`의 fallbackRender의 인자 중 하나인 `resetErrorBoundary`를 Fallback 컴포넌트에 넘겨주는 방식을 적용했습니다. Fallback 컴포넌트에서는 `resetErrorBoundary`를 `useDisplayedError`로 넘겨줍니다. `useDisplayedError`에서 Fallback 컴포넌트의 버튼 기능을 담당하고 있는데요, 여기서 switch case를 통해 retry 조건문에서 resetErrorBoundary를 실행해 에러가 발생했던 쿼리를 다시 실행할 수 있도록 합니다.

```tsx
// useDisplayedError.tsx

const useDisplayedError = (statusCode: number, resetErrorBoundary: () => void) => {
  const errorMessage = displayErrorMessage(statusCode);
  const navigate = useNavigate();

  const handleErrorButton = () => {
    switch (errorMessage.action) {
      case 'navigateBack':
        navigate(-1);
        break;
      case 'retry':
        resetErrorBoundary();
        break;
      case 'navigateHome':
        navigate('/');
        break;
    }
  };

  return { errorMessage, handleErrorButton };
};
```

### 동작 영상

https://github.com/user-attachments/assets/a5749095-c3bc-4d4c-a828-0ee74311ecb3

