### PR TITLE
[FE] 지도 렌더링 최적화 Issue #169

### DIFF
--- a/frontend/src/components/Feed/FeedEdit/FeedEdit.tsx
+++ b/frontend/src/components/Feed/FeedEdit/FeedEdit.tsx
@@ -4,7 +4,7 @@ import Button from '@/components/_common/Button/Button';
 import TextArea from '@/components/_common/TextArea/TextArea';
 import useFeedEdit from '@/hooks/Feed/useFeedEdit';
 import useImageUploader from '@/hooks/Feed/useImageUploader';
-import useTreeMap from '@/hooks/TreeMap/useTreeMap';
+import useMapAddress from '@/hooks/TreeMap/useMapAddress';
 import useFeedQuery from '@/queries/Feed/useFeedQuery';
 import { FEED } from '@/constants/feed';
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
@@ -18,7 +18,7 @@ interface FeedEditProps {
 
 const FeedEdit = ({ feedId, treeId }: FeedEditProps) => {
   const { feed } = useFeedQuery(feedId);
-  const { getAddress, currentAddress } = useTreeMap();
+  const { getAddress, address } = useMapAddress();
   const { imageUrl, fileInputRef, handleImageUploadClick, handleImageChange } = useImageUploader();
   const { content, isContentError, handleContentChange, handleSubmit } = useFeedEdit({
     feedId,
@@ -46,7 +46,7 @@ const FeedEdit = ({ feedId, treeId }: FeedEditProps) => {
         <p className={S.SelectMarkerText}>
           현재 트리 주소
           <br />
-          {currentAddress}
+          {address}
         </p>
       </div>
 

--- a/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
+++ b/frontend/src/components/Feed/FeedSubmit/FeedSubmit.tsx
@@ -6,7 +6,7 @@ import Input from '@/components/_common/Input/Input';
 import TextArea from '@/components/_common/TextArea/TextArea';
 import useFeedSubmit from '@/hooks/Feed/useFeedSubmit';
 import useImageUploader from '@/hooks/Feed/useImageUploader';
-import useTreeMap from '@/hooks/TreeMap/useTreeMap';
+import useMapAddress from '@/hooks/TreeMap/useMapAddress';
 import { FEED } from '@/constants/feed';
 import mapIcon from '@/assets/map.png';
 import * as S from './FeedSubmit.css';
@@ -15,7 +15,7 @@ const FeedSubmit = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { getAddress, currentAddress } = useTreeMap();
+  const { getAddress, address } = useMapAddress();
   const { imageUrl, imageFile, fileInputRef, handleImageUploadClick, handleImageChange } = useImageUploader();
   const {
     content,
@@ -47,7 +47,7 @@ const FeedSubmit = () => {
           <p className={S.SelectMarkerText}>
             현재 선택된 주소
             <br />
-            {currentAddress}
+            {address}
           </p>
         </div>
         <div className={S.AddressSelectButtonBox}>

--- a/frontend/src/hooks/TreeMap/useMapAddress.ts
+++ b/frontend/src/hooks/TreeMap/useMapAddress.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState } from 'react';
+
+const { kakao } = window;
+
+const useMapAddress = () => {
+  const [address, setAddress] = useState('');
+
+  const getAddress = useCallback((latitude: number, longitude: number): void => {
+    const geocoder = new kakao.maps.services.Geocoder();
+    const coord = new kakao.maps.LatLng(latitude, longitude);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    geocoder.coord2Address(coord.getLng(), coord.getLat(), (result: any, status: any) => {
+      if (status === kakao.maps.services.Status.OK) {
+        const addr = result[0].road_address?.address_name || result[0].address.address_name;
+        setAddress(addr);
+      } else {
+        setAddress('주소 정보를 찾을 수 없습니다.');
+      }
+    });
+  }, []);
+
+  return { address, getAddress };
+};
+
+export default useMapAddress;

--- a/frontend/src/hooks/TreeMap/usePlaceSearch.ts
+++ b/frontend/src/hooks/TreeMap/usePlaceSearch.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+const { kakao } = window;
+
+export interface Place {
+  id: string;
+  place_name: string;
+  x: string;
+  y: string;
+  address_name: string;
+}
+
+const usePlaceSearch = () => {
+  const [results, setResults] = useState<Place[]>([]);
+
+  const searchPlaces = (keyword: string) => {
+    if (!keyword) return;
+
+    const ps = new kakao.maps.services.Places();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ps.keywordSearch(keyword, (data: any, status: any) => {
+      if (status === kakao.maps.services.Status.OK) {
+        setResults(data);
+      } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
+        setResults([]);
+      } else if (status === kakao.maps.services.Status.ERROR) {
+        console.error('검색 에러');
+      }
+    });
+  };
+
+  return { results, searchPlaces };
+};
+
+export default usePlaceSearch;

--- a/frontend/src/hooks/TreeMap/useTreeMap.ts
+++ b/frontend/src/hooks/TreeMap/useTreeMap.ts
@@ -1,10 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { CourseWithPosition } from '@/pages/Course/Course.type';
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
 import treeImage from '@/assets/TREE_01.png';
 
 const { kakao } = window;
-
 const DEFAULT_ZOOM_LEVEL = 3;
 
 const MARKER_IMAGE: Record<string, string> = {
@@ -13,117 +11,81 @@ const MARKER_IMAGE: Record<string, string> = {
 
 const useTreeMap = () => {
   const mapRef = useRef<HTMLDivElement | null>(null);
-
-  const [map, setMap] = useState<typeof kakao | null>(null);
+  const [map, setMap] = useState<typeof kakao.maps.Map | null>(null);
   const [centerPosition, setCenterPosition] = useState({
     latitude: DEFAULT_LATITUDE,
     longitude: DEFAULT_LONGITUDE,
   });
 
-  const [currentAddress, setCurrentAddress] = useState('');
-  const [searchedPlaceList, setSearchedPlaceList] = useState<CourseWithPosition[]>([]);
-
   const initializeMap = (latitude: number, longitude: number) => {
     if (mapRef.current && kakao && kakao.maps) {
-      const options = { center: new kakao.maps.LatLng(latitude, longitude), level: DEFAULT_ZOOM_LEVEL };
-      const map = new kakao.maps.Map(mapRef.current, options);
-
-      setMap(map);
+      const options = {
+        center: new kakao.maps.LatLng(latitude, longitude),
+        level: DEFAULT_ZOOM_LEVEL,
+      };
+      const mapInstance = new kakao.maps.Map(mapRef.current, options);
+      setMap(mapInstance);
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const addMarker = (map: any, latitude: number, longitude: number, imageCode: string, onClick?: () => void) => {
-    const MARKER_SIZE = new kakao.maps.Size(50, 55);
-    const MARKER_OPTIONS = { offset: new kakao.maps.Point(25, 55) };
-
+  const addMarker = (
+    map: typeof kakao.maps.Map,
+    latitude: number,
+    longitude: number,
+    imageCode: string,
+    onClick?: () => void,
+  ) => {
     const markerPosition = new kakao.maps.LatLng(latitude, longitude);
-    const markerImage = new kakao.maps.MarkerImage(MARKER_IMAGE[imageCode], MARKER_SIZE, MARKER_OPTIONS);
-    const marker = new kakao.maps.Marker({ position: markerPosition, image: markerImage, clickable: true });
-
+    const markerImage = new kakao.maps.MarkerImage(MARKER_IMAGE[imageCode], new kakao.maps.Size(50, 55), {
+      offset: new kakao.maps.Point(25, 55),
+    });
+    const marker = new kakao.maps.Marker({
+      position: markerPosition,
+      image: markerImage,
+      clickable: true,
+    });
     if (onClick) kakao.maps.event.addListener(marker, 'click', onClick);
-
     marker.setMap(map);
   };
 
-  const getAddress = useCallback((latitude: number, longitude: number): void => {
-    const geocoder = new kakao.maps.services.Geocoder();
-    const coord = new kakao.maps.LatLng(latitude, longitude);
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    geocoder.coord2Address(coord.getLng(), coord.getLat(), (result: any, status: any) => {
-      if (status === kakao.maps.services.Status.OK) {
-        const address = result[0].road_address ? result[0].road_address.address_name : result[0].address.address_name;
-        setCurrentAddress(address);
-      } else {
-        setCurrentAddress('주소 정보를 찾을 수 없습니다.');
-      }
-    });
-  }, []);
-
-  const searchPlaces = (keyword: string) => {
-    if (!keyword) return;
-
-    const places = new kakao.maps.services.Places();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return places.keywordSearch(keyword, (data: any[], status: any) => {
-      if (status === kakao.maps.services.Status.OK) {
-        setSearchedPlaceList(data);
-      } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
-        return;
-      } else if (status === kakao.maps.services.Status.ERROR) {
-        return;
-      }
-    });
-  };
-
   const handleCenterChanged = useCallback(() => {
-    if (map) {
-      const center = map.getCenter();
-      setCenterPosition({ latitude: center.getLat(), longitude: center.getLng() });
-    }
+    if (!map) return;
+    const center = map.getCenter();
+    setCenterPosition({ latitude: center.getLat(), longitude: center.getLng() });
   }, [map]);
 
   useEffect(() => {
-    const savedLocation = sessionStorage.getItem('userLocation');
-
-    if (savedLocation) {
-      const { latitude, longitude } = JSON.parse(savedLocation);
+    const saved = sessionStorage.getItem('userLocation');
+    if (saved) {
+      const { latitude, longitude } = JSON.parse(saved);
       initializeMap(latitude, longitude);
-      return;
-    }
-
-    if (!navigator.geolocation) {
+    } else if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const { latitude, longitude } = pos.coords;
+          sessionStorage.setItem('userLocation', JSON.stringify({ latitude, longitude }));
+          initializeMap(latitude, longitude);
+        },
+        () => initializeMap(DEFAULT_LATITUDE, DEFAULT_LONGITUDE),
+      );
+    } else {
       initializeMap(DEFAULT_LATITUDE, DEFAULT_LONGITUDE);
-      return;
     }
-
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        const { latitude, longitude } = position.coords;
-        sessionStorage.setItem('userLocation', JSON.stringify({ latitude, longitude }));
-        initializeMap(latitude, longitude);
-      },
-      () => initializeMap(DEFAULT_LATITUDE, DEFAULT_LONGITUDE),
-    );
   }, []);
 
   useEffect(() => {
     if (!map) return;
-
     kakao.maps.event.addListener(map, 'dragend', handleCenterChanged);
-    return () => kakao.maps.event.removeListener(map, 'dragend', handleCenterChanged);
+    return () => {
+      kakao.maps.event.removeListener(map, 'dragend', handleCenterChanged);
+    };
   }, [map]);
 
   return {
     map,
     mapRef,
-    currentAddress,
     centerPosition,
     addMarker,
-    getAddress,
-    searchPlaces,
-    searchedPlaceList,
   };
 };
 

--- a/frontend/src/hooks/TreeMap/useTreeMap.ts
+++ b/frontend/src/hooks/TreeMap/useTreeMap.ts
@@ -72,7 +72,6 @@ const useTreeMap = () => {
     map,
     mapRef,
     centerPosition,
-    initialCenter,
     addMarker,
   };
 };

--- a/frontend/src/hooks/TreeMap/useTreeMap.ts
+++ b/frontend/src/hooks/TreeMap/useTreeMap.ts
@@ -85,13 +85,26 @@ const useTreeMap = () => {
   }, [map]);
 
   useEffect(() => {
+    const savedLocation = sessionStorage.getItem('userLocation');
+
+    if (savedLocation) {
+      const { latitude, longitude } = JSON.parse(savedLocation);
+      initializeMap(latitude, longitude);
+      return;
+    }
+
     if (!navigator.geolocation) {
       initializeMap(DEFAULT_LATITUDE, DEFAULT_LONGITUDE);
       return;
     }
 
-    navigator.geolocation.getCurrentPosition((position) =>
-      initializeMap(position.coords.latitude, position.coords.longitude),
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        sessionStorage.setItem('userLocation', JSON.stringify({ latitude, longitude }));
+        initializeMap(latitude, longitude);
+      },
+      () => initializeMap(DEFAULT_LATITUDE, DEFAULT_LONGITUDE),
     );
   }, []);
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,6 +12,8 @@ export const queryClient = new QueryClient({
     queries: {
       throwOnError: true,
       retry: 0,
+      staleTime: 5 * 60 * 1000,
+      gcTime: 30 * 60 * 1000,
     },
   },
 });

--- a/frontend/src/pages/Course/CourseMain/CourseMain.tsx
+++ b/frontend/src/pages/Course/CourseMain/CourseMain.tsx
@@ -5,7 +5,8 @@ import { IoIosSearch } from '@react-icons/all-files/io/IoIosSearch';
 import InputComboBox from '@/components/_common/InputComboBox/InputComboBox';
 import CourseItem from '@/components/Course/CourseItem/CourseItem';
 import { useDebounce } from '@/hooks/_common/useDebounce';
-import useTreeMap from '@/hooks/TreeMap/useTreeMap';
+import useMapAddress from '@/hooks/TreeMap/useMapAddress';
+import usePlaceSearch from '@/hooks/TreeMap/usePlaceSearch';
 import useAttractionsQuery from '@/queries/Course/useAttractionsQuery';
 import { extractAddressPart } from '@/utils/extractAddressPart';
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
@@ -26,14 +27,15 @@ const CourseMain = () => {
 
   const navigate = useNavigate();
 
-  const { getAddress, currentAddress, searchPlaces, searchedPlaceList } = useTreeMap();
+  const { results, searchPlaces } = usePlaceSearch();
+  const { getAddress, address } = useMapAddress();
   const { attractionList } = useAttractionsQuery(currentPosition.latitude, currentPosition.longitude);
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
     const data = formData.get('searchedComboBox');
-    const selectedPlace = searchedPlaceList.find((place) => place.place_name === data);
+    const selectedPlace = results.find((place) => place.place_name === data);
     if (!selectedPlace) return;
 
     navigate(`/course/detail?keyword=${data}&latitude=${selectedPlace.y}&longitude=${selectedPlace.x}`);
@@ -55,7 +57,7 @@ const CourseMain = () => {
     searchPlaces(`${debouncedInputValue}`);
   }, [debouncedInputValue]);
 
-  const currentCity = extractAddressPart(currentAddress, '시');
+  const currentCity = extractAddressPart(address, '시');
 
   return (
     <div className={S.Layout}>
@@ -64,7 +66,7 @@ const CourseMain = () => {
         <form className={S.FormSection} onSubmit={handleSubmit}>
           <InputComboBox
             label="어디로 떠나시나요?<br/>직접 선별한 코스를 알려드려요!"
-            comboBoxList={searchedPlaceList}
+            comboBoxList={results}
             value={inputValue}
             canSubmitByInput={false}
             buttonType="submit"

--- a/frontend/src/pages/Landing/Landing.tsx
+++ b/frontend/src/pages/Landing/Landing.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import Button from '@/components/_common/Button/Button';
 import SnowAnimation from '@/components/Landing/SnowAnimation/SnowAnimation';
+import { getTrees } from '@/apis/tree';
+import { TREE_KEYS } from '@/queries/queryKeys';
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
 import Garland from '@/assets/garland.svg';
 import Snowman from '@/assets/snowman.svg';
@@ -46,7 +48,8 @@ const Landing = () => {
     const location = savedLocation ? JSON.parse(savedLocation) : FALLBACK_LOCATION;
 
     queryClient.prefetchQuery({
-      queryKey: ['trees', location],
+      queryKey: [TREE_KEYS.TREES, location.latitude, location.longitude],
+      queryFn: () => getTrees({ latitude: location.latitude, longitude: location.longitude }),
     });
   };
 

--- a/frontend/src/pages/Landing/Landing.tsx
+++ b/frontend/src/pages/Landing/Landing.tsx
@@ -1,11 +1,44 @@
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import Button from '@/components/_common/Button/Button';
 import SnowAnimation from '@/components/Landing/SnowAnimation/SnowAnimation';
+import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '@/constants/map';
 import Garland from '@/assets/garland.svg';
 import Snowman from '@/assets/snowman.svg';
 import * as S from './Landing.css';
 
 const Landing = () => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          sessionStorage.setItem(
+            'userLocation',
+            JSON.stringify({
+              latitude: position.coords.latitude,
+              longitude: position.coords.longitude,
+            }),
+          );
+        },
+        () => {
+          sessionStorage.setItem(
+            'userLocation',
+            JSON.stringify({
+              latitude: DEFAULT_LATITUDE,
+              longitude: DEFAULT_LONGITUDE,
+            }),
+          );
+        },
+      );
+    }
+
+    import('@/pages/TreeMap/TreeMap');
+    import('@/hooks/TreeMap/useTreeMap');
+  }, []);
+
   return (
     <div className={S.Layout}>
       <div className={S.CircleContainer}>
@@ -28,9 +61,6 @@ const Landing = () => {
           낭만적인 크리스마스를 만들어 보세요!
         </p>
         <div className={S.ButtonContainer}>
-          {/* <Button color="primary" disabled={true}>
-            5초 만에 로그인하고 시작하기
-          </Button> */}
           <Link to="/map">
             <Button color="secondary">시작하기</Button>
           </Link>

--- a/frontend/src/pages/Landing/Landing.tsx
+++ b/frontend/src/pages/Landing/Landing.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import Button from '@/components/_common/Button/Button';
 import SnowAnimation from '@/components/Landing/SnowAnimation/SnowAnimation';
@@ -16,13 +16,12 @@ const FALLBACK_LOCATION = {
 };
 
 const Landing = () => {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [isLocationReady, setIsLocationReady] = useState(false);
 
   useEffect(() => {
     const setLocation = (location: typeof FALLBACK_LOCATION) => {
       sessionStorage.setItem('userLocation', JSON.stringify(location));
-      setIsLocationReady(true);
     };
 
     if (navigator.geolocation) {
@@ -53,6 +52,10 @@ const Landing = () => {
     });
   };
 
+  const handleButtonClick = () => {
+    navigate('/map');
+  };
+
   return (
     <div className={S.Layout}>
       <div className={S.CircleContainer}>
@@ -75,16 +78,14 @@ const Landing = () => {
           낭만적인 크리스마스를 만들어 보세요!
         </p>
         <div className={S.ButtonContainer}>
-          <Link to="/map">
-            <Button
-              color="secondary"
-              onTouchStart={handleButtonPrefetch}
-              onMouseEnter={handleButtonPrefetch}
-              disabled={!isLocationReady}
-            >
-              {isLocationReady ? '시작하기' : '위치 불러오는 중...'}
-            </Button>
-          </Link>
+          <Button
+            color="secondary"
+            onTouchStart={handleButtonPrefetch}
+            onMouseEnter={handleButtonPrefetch}
+            onClick={handleButtonClick}
+          >
+            시작하기
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/TreeMap/TreeMap.tsx
+++ b/frontend/src/pages/TreeMap/TreeMap.tsx
@@ -13,8 +13,8 @@ const TreeMap = () => {
   const navigate = useNavigate();
 
   const { isModalOpen, openModal, closeModal } = useModal();
-  const { map, mapRef, addMarker, centerPosition } = useTreeMap();
-  const { trees, isSuccess } = useTreesQuery(centerPosition);
+  const { map, mapRef, addMarker, centerPosition, initialCenter } = useTreeMap();
+  const { trees, isSuccess } = useTreesQuery(initialCenter);
   const handleMarkerClick = (treeId: number) => {
     openModal();
     navigate(`/map/${treeId}?modal=feeds`);

--- a/frontend/src/pages/TreeMap/TreeMap.tsx
+++ b/frontend/src/pages/TreeMap/TreeMap.tsx
@@ -13,8 +13,8 @@ const TreeMap = () => {
   const navigate = useNavigate();
 
   const { isModalOpen, openModal, closeModal } = useModal();
-  const { map, mapRef, addMarker, centerPosition, initialCenter } = useTreeMap();
-  const { trees, isSuccess } = useTreesQuery(initialCenter);
+  const { map, mapRef, addMarker, centerPosition } = useTreeMap();
+  const { trees, isSuccess } = useTreesQuery(centerPosition);
   const handleMarkerClick = (treeId: number) => {
     openModal();
     navigate(`/map/${treeId}?modal=feeds`);


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #169 

## ✨ 구현한 기능

1. 지도 렌더링 최적화
2. useTreeMap을 역할에 따라 분리


## ✏️ 자세한 구현 내용

### 지도 렌더링 최적화
- 랜딩 페이지를 지나 지도 페이지 (TreeMap) 에서 위치 정보를 받아 지도를 첫 렌더하는 과정에서 많은 시간이 소요된다고 생각했습니다.
- 따라서 랜딩 페이지에서 위치 정보를 받고 map을 pre-load하는 방식으로 최적화를 진행했습니다.

1. 랜딩 페이지에서의 위치 정보 사전 동의

- `랜딩 페이지 -> 지도 페이지 -> 위치 정보 동의 -> 지도 렌더` 과정을 `랜딩 페이지 -> 위치 정보 동의 -> 지도 페이지 및 지도 렌더`로 변경했습니다.
- `navigator`로 위치를 받아 세션 스토리지에 저장한 뒤, `useTreeMap`에서 `initialCenter`에 저장된 좌표를 가져와 초기 `centerPosition`에 저장됩니다.


2. 랜딩 페이지에서의 시작 버튼을 누르는 순간 컴포넌트 및 데이터 prefetch

- 시작 버튼을 누르거나 마우스를 올릴 때 prefetch 핸들러가 동작하도록 했습니다. (모바일은 onTouchStart, 데스크탑은 onMouseEnter)
- 먼저 `TreeMap` 컴포넌트와 `useTreeMap` 훅을 pre-load하고, queryClient의 `prefetchQuery`로 전체 Tree를 가져오는 `getTrees`를 실행합니다. Trees는 캐싱되어 저장되고, 이후 지도 페이지 최초 진입 시 캐싱된 Trees를 활용하기 때문에 `getTrees`를 호출하지 않습니다.


### useTreeMap을 역할에 따라 분리
- `useTreeMap`의 역할이 혼재되어 있어 분리했습니다.
  - 주소를 담당하는 `useMapAddress`
  - 장소 검색을 담당하는 `usePlaceSearch`

### 지도 페이지 개선 전후 비교

|지표|개선 전|개선 후|
|---|---|---|
|TBT|300ms|80ms|
|FCP|11.9s|11.5s|
|LCP|23.1s|22.7s|

- 카카오맵 라이브러리로 지도를 렌더링해야 하는 도메인 특성상 LCP가 높은 것은 어쩔 수 없지만, TBT 시간이 유의미하게 줄은 것을 확인할 수 있습니다!
- 추가적으로 NavBar를 먼저 렌더링하는 등의 작업으로 FCP를 개선해 볼 수도 있을 것 같아요.