### PR TITLE
[BE] 피드 시간 & 피드 없는 트리 삭제 Issue #191

### DIFF
--- a/backend/src/main/java/com/christmas/feed/repository/FeedRepository.java
+++ b/backend/src/main/java/com/christmas/feed/repository/FeedRepository.java
@@ -15,7 +15,7 @@ public interface FeedRepository extends JpaRepository<FeedEntity, Long> {
     @Query("SELECT COUNT(f) FROM FeedEntity AS f WHERE f.nickname LIKE :nickname%")
     int countAllByNickname(String nickname);
 
-    long countByTreeEntity(TreeEntity treeEntity);
+    boolean existsByTreeEntity(TreeEntity treeEntity);
 
     List<FeedEntity> findAllByTreeEntityOrderByCreatedAtDesc(TreeEntity treeEntity);
 }

--- a/backend/src/main/java/com/christmas/feed/repository/FeedRepository.java
+++ b/backend/src/main/java/com/christmas/feed/repository/FeedRepository.java
@@ -15,5 +15,7 @@ public interface FeedRepository extends JpaRepository<FeedEntity, Long> {
     @Query("SELECT COUNT(f) FROM FeedEntity AS f WHERE f.nickname LIKE :nickname%")
     int countAllByNickname(String nickname);
 
+    long countByTreeEntity(TreeEntity treeEntity);
+
     List<FeedEntity> findAllByTreeEntityOrderByCreatedAtDesc(TreeEntity treeEntity);
 }

--- a/backend/src/main/java/com/christmas/feed/service/FeedService.java
+++ b/backend/src/main/java/com/christmas/feed/service/FeedService.java
@@ -130,6 +130,7 @@ public class FeedService {
             throw new InvalidPasswordException(FeedErrorCode.INVALID_PASSWORD, Map.of("password", password));
         }
         deleteFeedCascade(id, feedEntity);
+        deleteTreeIfNoFeeds(feedEntity.getTreeEntity());
         return id;
     }
 
@@ -138,6 +139,13 @@ public class FeedService {
         feedImageFileRepository.deleteByFeedEntity(feedEntity);
         imageFileService.deleteImage(feedImageFileEntity.getImageFileEntity());
         feedRepository.deleteById(id);
+    }
+
+    private void deleteTreeIfNoFeeds(TreeEntity treeEntity) {
+        long feedCount = feedRepository.countByTreeEntity(treeEntity);
+        if (feedCount == 0) {
+            treeRepository.deleteById(treeEntity.getId());
+        }
     }
 
     public long deleteLike(long id) {

--- a/backend/src/main/java/com/christmas/feed/service/FeedService.java
+++ b/backend/src/main/java/com/christmas/feed/service/FeedService.java
@@ -142,8 +142,8 @@ public class FeedService {
     }
 
     private void deleteTreeIfNoFeeds(TreeEntity treeEntity) {
-        long feedCount = feedRepository.countByTreeEntity(treeEntity);
-        if (feedCount == 0) {
+        boolean isExistFeed = feedRepository.existsByTreeEntity(treeEntity);
+        if (!isExistFeed) {
             treeRepository.deleteById(treeEntity.getId());
         }
     }

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -23,6 +23,8 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+        jdbc:
+          time_zone: Asia/Seoul
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -23,6 +23,8 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+        jdbc:
+          time_zone: Asia/Seoul
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/backend/src/test/java/com/christmas/feed/service/FeedServiceTest.java
+++ b/backend/src/test/java/com/christmas/feed/service/FeedServiceTest.java
@@ -125,4 +125,21 @@ class FeedServiceTest {
         FeedImageFileEntity feedImageFileEntity = feedImageFileRepository.findByFeedEntity(feedEntity);
         assertThat(response.imageUrl()).isEqualTo(feedImageFileEntity.getImageFileEntity().getImageUrl());
     }
+
+    @Test
+    @DisplayName("피드 삭제 - 피드 삭제 시 트리에 피드가 하나도 없으면 트리도 삭제한다.")
+    void delete_feed_with_tree() {
+        // given
+        TreeEntity treeEntity = treeRepository.save(new TreeEntity(PointGenerator.generate(127.2, 30.5), "IMAGE_CODE"));
+        MultipartFile oldImage = new MockMultipartFile("oldImage", "oldContent".getBytes());
+        FeedCreateRequest feedCreateRequest = new FeedCreateRequest(treeEntity.getId(), "content", "password123");
+        long id = feedService.createFeed(feedCreateRequest, oldImage);
+
+        // when
+        long deletedId = feedService.deleteFeed(id, feedCreateRequest.password());
+
+        // then
+        assertThat(feedRepository.existsById(deletedId)).isFalse();
+        assertThat(treeRepository.existsById(treeEntity.getId())).isFalse();
+    }
 }


### PR DESCRIPTION
## 📌 연관된 이슈

- closes: #191 

## ✨ 구현한 기능
- 피드 생성/수정 시간을 Asia/Seoul로 고정
- 피드 삭제 시 트리에 피드가 하나도 없을 경우 트리도 삭제
  - 테스트 완료 