### PR TITLE
[FE] 피드 삭제 api 응답 형식 변경 Issue #197

### DIFF
--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -72,7 +72,7 @@ interface DeleteFeedRequest {
 
 interface DeleteFeedResponse {
   treeId: number;
-  hasTree: boolean;
+  hasFeed: boolean;
 }
 
 export const deleteFeed = async ({ feedId, password }: DeleteFeedRequest) => {

--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -70,8 +70,13 @@ interface DeleteFeedRequest {
   password: string;
 }
 
+interface DeleteFeedResponse {
+  treeId: number;
+  hasTree: boolean;
+}
+
 export const deleteFeed = async ({ feedId, password }: DeleteFeedRequest) => {
-  return await requestAPI.delete<number>(`/feed/${feedId}`, { password });
+  return await requestAPI.delete<DeleteFeedResponse>(`/feed/${feedId}`, { password });
 };
 
 interface PostLikeFeedRequest {

--- a/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
+++ b/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
@@ -35,8 +35,8 @@ const FeedPasswordVerification = () => {
               deleteFeedMutation(
                 { feedId, password },
                 {
-                  onSuccess: ({ treeId, hasTree }) => {
-                    if (!hasTree) {
+                  onSuccess: ({ treeId, hasFeed }) => {
+                    if (!hasFeed) {
                       navigate(`/map`, { replace: true });
                       return;
                     }

--- a/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
+++ b/frontend/src/components/Feed/FeedPasswordVerification/FeedPasswordVerification.tsx
@@ -35,7 +35,11 @@ const FeedPasswordVerification = () => {
               deleteFeedMutation(
                 { feedId, password },
                 {
-                  onSuccess: () => {
+                  onSuccess: ({ treeId, hasTree }) => {
+                    if (!hasTree) {
+                      navigate(`/map`, { replace: true });
+                      return;
+                    }
                     navigate(`/map/${treeId}?modal=feeds`);
                   },
                 },

--- a/frontend/src/mocks/handlers/feed.ts
+++ b/frontend/src/mocks/handlers/feed.ts
@@ -14,22 +14,24 @@ export const handlers = [
     try {
       const formData = await request.formData();
       const imageFile = formData.get('image') as File;
-      const requestData = formData.get('request');
+      let requestData = formData.get('request');
 
       if (!imageFile || !requestData) {
         return HttpResponse.json({ message: '이미지와 요청 데이터가 필요합니다.' }, { status: 400 });
       }
 
-      const parsedRequest = JSON.parse(requestData as string);
-      const { content, likeCount } = parsedRequest;
-
+      if (requestData instanceof File) {
+        requestData = await requestData.text();
+      }
+      const parsedRequest = JSON.parse(requestData);
+      const { content } = parsedRequest;
       const newFeed = {
         id: mockFeeds.length + 1,
         treeImageCode: 'TREE_01',
         nickname: '토끼',
         updatedAt: new Date().toISOString(),
         imageUrl: 'https://picsum.photos/id/30/500',
-        likeCount,
+        likeCount: 0,
         content,
       };
       mockFeeds.push(newFeed);
@@ -138,10 +140,19 @@ export const handlers = [
     return HttpResponse.json(true);
   }),
 
-  http.delete(`${API_URL}/feed/:feedId`, async ({ request }) => {
-    const url = new URL(request.url);
-    const feedId = Number(url.pathname.split('/').at(-1));
-    feeds = feeds.filter((feed) => feed.id !== feedId);
-    return HttpResponse.json({ status: 200, feedId });
+  http.delete(`${API_URL}/feed/:treeId`, async ({ params }) => {
+    const { treeId } = params;
+    if (!treeId) {
+      return HttpResponse.json({ message: '트리 ID를 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    feeds = feeds.filter((feed) => feed.id !== Number(treeId));
+
+    const response = {
+      treeId: Number(treeId),
+      hasTree: feeds.length > 0,
+    };
+
+    return HttpResponse.json(response);
   }),
 ];

--- a/frontend/src/mocks/handlers/feed.ts
+++ b/frontend/src/mocks/handlers/feed.ts
@@ -150,7 +150,7 @@ export const handlers = [
 
     const response = {
       treeId: Number(treeId),
-      hasTree: feeds.length > 0,
+      hasFeed: feeds.length > 0,
     };
 
     return HttpResponse.json(response);

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -44,7 +44,7 @@ const useFeedMutation = () => {
 
   const { mutate: deleteFeedMutation } = useMutation({
     mutationFn: deleteFeed,
-    onSuccess: (treeId) => {
+    onSuccess: ({ treeId }) => {
       queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
     },
   });


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #197 

## ✨ 구현한 기능

- 피드 삭제 시 응답에 따라 라우팅 분기 처리 적용

## ✏️ 자세한 구현 내용

- 피드 삭제 시 해당 트리에 잔여 피드가 더이상 없는 경우 트리가 삭제되는 정책으로 변경되었습니다. 이에 따라 서버에서 응답한 `hasFeed`을 통해 지도 `/map` 또는 피드 `/map/{treeId}?modal=feeds`로 이동하도록 분기를 나누었습니다.
