### PR TITLE
[FE] 피드 좋아요 취소 시 서버 응답값이 반영되지 않는 현상 해결 Issue #205

### DIFF
--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -81,18 +81,20 @@ export const deleteFeed = async ({ feedId, password }: DeleteFeedRequest) => {
 
 interface PostLikeFeedRequest {
   feedId: number;
+  treeId: number;
 }
 
-export const postLikeFeed = async ({ feedId }: PostLikeFeedRequest) => {
-  await requestAPI.post<number>(`/feed/${feedId}/like`);
+export const postLikeFeed = async ({ feedId }: PostLikeFeedRequest): Promise<number> => {
+  return await requestAPI.post<number>(`/feed/${feedId}/like`);
 };
 
 interface DeleteLikeFeedRequest {
   feedId: number;
+  treeId: number;
 }
 
-export const deleteLikeFeed = async ({ feedId }: DeleteLikeFeedRequest) => {
-  await requestAPI.delete(`/feed/${feedId}/like`);
+export const deleteLikeFeed = async ({ feedId }: DeleteLikeFeedRequest): Promise<number> => {
+  return await requestAPI.delete<number>(`/feed/${feedId}/like`);
 };
 
 interface PostFeedPasswordRequest {

--- a/frontend/src/components/Feed/FeedItem/FeedItem.tsx
+++ b/frontend/src/components/Feed/FeedItem/FeedItem.tsx
@@ -47,9 +47,9 @@ const FeedItem = ({ feed, treeId }: FeedItemProps) => {
 
   const handleLiked = () => {
     if (isSelected) {
-      deleteLikeFeedMutation({ feedId: id });
+      deleteLikeFeedMutation({ feedId: id, treeId });
     } else {
-      addLikeFeedMutation({ feedId: id });
+      addLikeFeedMutation({ feedId: id, treeId });
     }
     manageLikedFeeds(treeId, id);
   };

--- a/frontend/src/components/Feed/FeedItem/FeedItem.tsx
+++ b/frontend/src/components/Feed/FeedItem/FeedItem.tsx
@@ -47,7 +47,10 @@ const FeedItem = ({ feed, treeId }: FeedItemProps) => {
 
   const handleLiked = () => {
     if (isSelected) {
-      deleteLikeFeedMutation({ feedId: id, treeId });
+      deleteLikeFeedMutation({
+        feedId: id,
+        treeId,
+      });
     } else {
       addLikeFeedMutation({ feedId: id, treeId });
     }

--- a/frontend/src/mocks/handlers/feed.ts
+++ b/frontend/src/mocks/handlers/feed.ts
@@ -85,6 +85,7 @@ export const handlers = [
     }
   }),
 
+  // 피드 좋아요
   http.post(`${API_URL}/feed/:id/like`, async ({ request }) => {
     const url = new URL(request.url);
     const feedId = Number(url.pathname.split('/').at(-2));
@@ -99,26 +100,10 @@ export const handlers = [
         }
       });
     }
-    return HttpResponse.json({ status: 200 });
+    return HttpResponse.json(mockFeeds.find((feed) => feed.id === feedId)?.likeCount ?? 0);
   }),
 
-  http.post(`${API_URL}/feed/:id/like`, async ({ request }) => {
-    const url = new URL(request.url);
-    const feedId = Number(url.pathname.split('/').at(-2));
-
-    if (mockFeeds.some((feed) => feed.id === feedId)) {
-      mockFeeds.forEach((feed, index) => {
-        if (feed.id === feedId) {
-          mockFeeds[index] = {
-            ...feed,
-            likeCount: feed.likeCount + 1,
-          };
-        }
-      });
-    }
-    return HttpResponse.json({ status: 200 });
-  }),
-
+  // 피드 좋아요 취소
   http.delete(`${API_URL}/feed/:id/like`, async ({ request }) => {
     const url = new URL(request.url);
     const feedId = Number(url.pathname.split('/').at(-2));
@@ -133,7 +118,7 @@ export const handlers = [
         }
       });
     }
-    return HttpResponse.json({ status: 200 });
+    return HttpResponse.json(mockFeeds.find((feed) => feed.id === feedId)?.likeCount ?? 0);
   }),
 
   http.post(`${API_URL}/feed/:feedId/verify-password`, async () => {

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -36,8 +36,10 @@ const useFeedMutation = () => {
       );
       return { ...previousFeeds };
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS] });
+    onSuccess: (newLikeCount, { feedId, treeId }) => {
+      queryClient.setQueryData<Feed[]>([FEED_KEYS.FEEDS, { treeId }], (oldFeeds?: Feed[]) =>
+        oldFeeds?.map((feed: Feed) => (feed.id === feedId ? { ...feed, likeCount: newLikeCount } : feed) ?? oldFeeds),
+      );
     },
   });
 
@@ -54,8 +56,10 @@ const useFeedMutation = () => {
       );
       return { ...previousFeeds };
     },
-    onSuccess: (treeId) => {
-      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
+    onSuccess: (newLikeCount, { feedId, treeId }) => {
+      queryClient.setQueryData<Feed[]>([FEED_KEYS.FEEDS, { treeId }], (oldFeeds?: Feed[]) =>
+        oldFeeds?.map((feed: Feed) => (feed.id === feedId ? { ...feed, likeCount: newLikeCount } : feed) ?? oldFeeds),
+      );
     },
   });
 

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -25,7 +25,12 @@ const useFeedMutation = () => {
     },
   });
 
-  const { mutate: addLikeFeedMutation } = useMutation({
+  const { mutate: addLikeFeedMutation } = useMutation<
+    number,
+    Error,
+    { feedId: number; treeId: number },
+    { previousFeeds?: Feed[] }
+  >({
     mutationFn: postLikeFeed,
     onMutate: ({ feedId, treeId }) => {
       const previousFeeds = queryClient.getQueryData<Feed[]>([FEED_KEYS.FEEDS, { treeId }]);
@@ -34,16 +39,26 @@ const useFeedMutation = () => {
         (oldFeeds?: Feed[]) =>
           oldFeeds?.map((feed) => (feed.id === feedId ? { ...feed, likeCount: feed.likeCount + 1 } : feed)) ?? oldFeeds,
       );
-      return { ...previousFeeds };
+      return { previousFeeds };
     },
     onSuccess: (newLikeCount, { feedId, treeId }) => {
       queryClient.setQueryData<Feed[]>([FEED_KEYS.FEEDS, { treeId }], (oldFeeds?: Feed[]) =>
         oldFeeds?.map((feed: Feed) => (feed.id === feedId ? { ...feed, likeCount: newLikeCount } : feed) ?? oldFeeds),
       );
     },
+    onError: (_err, { treeId }, context) => {
+      if (context?.previousFeeds) {
+        queryClient.setQueryData([FEED_KEYS.FEEDS, { treeId }], context.previousFeeds);
+      }
+    },
   });
 
-  const { mutate: deleteLikeFeedMutation } = useMutation({
+  const { mutate: deleteLikeFeedMutation } = useMutation<
+    number,
+    Error,
+    { feedId: number; treeId: number },
+    { previousFeeds?: Feed[] }
+  >({
     mutationFn: deleteLikeFeed,
     onMutate: ({ feedId, treeId }) => {
       const previousFeeds = queryClient.getQueryData<Feed[]>([FEED_KEYS.FEEDS, { treeId }]);
@@ -54,12 +69,17 @@ const useFeedMutation = () => {
             feed.id === feedId ? { ...feed, likeCount: Math.max(0, feed.likeCount - 1) } : feed,
           ) ?? oldFeeds,
       );
-      return { ...previousFeeds };
+      return { previousFeeds };
     },
     onSuccess: (newLikeCount, { feedId, treeId }) => {
       queryClient.setQueryData<Feed[]>([FEED_KEYS.FEEDS, { treeId }], (oldFeeds?: Feed[]) =>
         oldFeeds?.map((feed: Feed) => (feed.id === feedId ? { ...feed, likeCount: newLikeCount } : feed) ?? oldFeeds),
       );
+    },
+    onError: (_err, { treeId }, context) => {
+      if (context?.previousFeeds) {
+        queryClient.setQueryData([FEED_KEYS.FEEDS, { treeId }], context.previousFeeds);
+      }
     },
   });
 

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { queryClient } from '@/main';
+import { Feed } from '@/types/feed.type';
 import { useMutation } from '@tanstack/react-query';
 import { deleteFeed, deleteLikeFeed, postFeed, postFeedPassword, postLikeFeed, updateFeed } from '@/apis/feed';
 import { FEED_KEYS } from '../queryKeys';
@@ -26,6 +27,15 @@ const useFeedMutation = () => {
 
   const { mutate: addLikeFeedMutation } = useMutation({
     mutationFn: postLikeFeed,
+    onMutate: ({ feedId, treeId }) => {
+      const previousFeeds = queryClient.getQueryData<Feed[]>([FEED_KEYS.FEEDS, { treeId }]);
+      queryClient.setQueryData<Feed[]>(
+        [FEED_KEYS.FEEDS, { treeId }],
+        (oldFeeds?: Feed[]) =>
+          oldFeeds?.map((feed) => (feed.id === feedId ? { ...feed, likeCount: feed.likeCount + 1 } : feed)) ?? oldFeeds,
+      );
+      return { ...previousFeeds };
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS] });
     },
@@ -33,6 +43,17 @@ const useFeedMutation = () => {
 
   const { mutate: deleteLikeFeedMutation } = useMutation({
     mutationFn: deleteLikeFeed,
+    onMutate: ({ feedId, treeId }) => {
+      const previousFeeds = queryClient.getQueryData<Feed[]>([FEED_KEYS.FEEDS, { treeId }]);
+      queryClient.setQueryData<Feed[]>(
+        [FEED_KEYS.FEEDS, { treeId }],
+        (oldFeeds?: Feed[]) =>
+          oldFeeds?.map((feed) =>
+            feed.id === feedId ? { ...feed, likeCount: Math.max(0, feed.likeCount - 1) } : feed,
+          ) ?? oldFeeds,
+      );
+      return { ...previousFeeds };
+    },
     onSuccess: (treeId) => {
       queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
     },


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #205 

## ✨ 구현한 기능

1. 좋아요 / 취소 시 Tanstack query 캐시를 직접 업데이트하도록 수정
2. 좋아요 / 취소 시 낙관적 업데이트 적용
3. 좋아요 / 취소 MSW 핸들러 - 업데이트 된 likeCount를 반환하도록 수정

## ✏️ 자세한 구현 내용

1. addLikeFeedMutation, deleteLikeFeedMutation에서 캐시를 직접 업데이트하도록 리팩토링
- onMutate의 낙관적 업데이트, onSuccess 콜백, onError 콜백에서 setQueryData로 캐시를 직접 업데이트하는 것으로 변경
- `["feeds", { "treeId": number }]` 데이터에서 feedId와 같은 데이터를 찾아 해당 데이터만 값을 업데이트 한 뒤 캐시에 반영하는 방식 적용

2. 낙관적 업데이트 적용
- mutation 발생 시 `onMutate`로 즉시 캐시를 업데이트 한 뒤, 응답이 성공적으로 반환되면 `onSuccess`에서 응답 받은 likeCount를 업데이트하고, 에러 발생 시 `onError`에서 이전 컨텍스트를 참조해 낙관적 업데이트 전 상태로 리셋되도록 적용
