### PR TITLE
[FE] 트리 수정 시 캐싱 업데이트 개선 Issue #211

### DIFF
--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -62,7 +62,7 @@ export const updateFeed = async ({ feedId, imageFile, content }: UpdateFeedReque
 
   formData.append('request', blob);
 
-  await requestAPI.patch(`/feed/${feedId}`, formData);
+  await requestAPI.patch<Partial<Feed>>(`/feed/${feedId}`, formData);
 };
 
 interface DeleteFeedRequest {

--- a/frontend/src/apis/feed.ts
+++ b/frontend/src/apis/feed.ts
@@ -62,7 +62,7 @@ export const updateFeed = async ({ feedId, imageFile, content }: UpdateFeedReque
 
   formData.append('request', blob);
 
-  await requestAPI.patch<Partial<Feed>>(`/feed/${feedId}`, formData);
+  await requestAPI.patch(`/feed/${feedId}`, formData);
 };
 
 interface DeleteFeedRequest {

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -18,9 +18,15 @@ const useFeedMutation = () => {
 
   const { mutateAsync: updateFeedMutation } = useMutation({
     mutationFn: updateFeed,
-    onSuccess: (feedId, { treeId }) => {
-      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
-      queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEED, { feedId }] });
+    onSuccess: (_, { treeId, feedId, content }) => {
+      queryClient.setQueryData<Feed[]>(
+        [FEED_KEYS.FEEDS, { treeId }],
+        (oldFeeds?: Feed[]) =>
+          oldFeeds?.map((feed) => (feed.id === Number(feedId) ? { ...feed, content } : feed)) ?? oldFeeds,
+      );
+      queryClient.setQueryData<Feed>([FEED_KEYS.FEED, { feedId }], (oldFeed?: Feed) =>
+        oldFeed ? { ...oldFeed, content } : oldFeed,
+      );
       navigate(`/map/${treeId}?modal=feeds`);
     },
   });

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -19,10 +19,8 @@ const useFeedMutation = () => {
   const { mutateAsync: updateFeedMutation } = useMutation({
     mutationFn: updateFeed,
     onSuccess: (_, { treeId, feedId, content }) => {
-      queryClient.setQueryData<Feed[]>(
-        [FEED_KEYS.FEEDS, { treeId }],
-        (oldFeeds?: Feed[]) =>
-          oldFeeds?.map((feed) => (feed.id === Number(feedId) ? { ...feed, content } : feed)) ?? oldFeeds,
+      queryClient.setQueryData<Feed[]>([FEED_KEYS.FEEDS, { treeId: Number(treeId) }], (oldFeeds?: Feed[]) =>
+        oldFeeds?.map((feed: Feed) => (feed.id === Number(feedId) ? { ...feed, content } : feed) ?? oldFeeds),
       );
       queryClient.setQueryData<Feed>([FEED_KEYS.FEED, { feedId }], (oldFeed?: Feed) =>
         oldFeed ? { ...oldFeed, content } : oldFeed,


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #211 

## ✨ 구현한 기능

피드 수정 시 캐싱 업데이트 개선

## ✏️ 자세한 구현 내용

- 피드 수정 시 캐싱이 업데이트 되지 않아 수정 전 내용으로 보여지는 현상을 해결했습니다.
- invalidateQueries를 setQueryData로 변경하여 쿼리 데이터를 직접 변경하는 것으로 개선했습니다.
