### PR TITLE
[FE] 신규 트리 생성 기준을 10m로 변경 #209

### DIFF
--- a/frontend/src/apis/tree.ts
+++ b/frontend/src/apis/tree.ts
@@ -18,6 +18,7 @@ interface GetTreesRequest {
 interface GetTreesResponse extends GetTreesRequest {
   id: number;
   imageCode: string;
+  distance: number;
 }
 
 export const getTrees = async ({ latitude, longitude }: GetTreesRequest) => {

--- a/frontend/src/hooks/Course/useCourseMap.ts
+++ b/frontend/src/hooks/Course/useCourseMap.ts
@@ -15,15 +15,15 @@ interface UseCourseMapProps {
   isStaticMap?: boolean;
 }
 
-const MARKER_CONFIG = {
-  SIZE: new kakao.maps.Size(36, 36),
-  OPTIONS: { offset: new kakao.maps.Point(18, 36) },
-} as const;
-
 const useCourseMap = ({ courseList, mapLevel = 5, isStaticMap = false }: UseCourseMapProps) => {
   const mapRef = useRef<HTMLDivElement | null>(null);
   const currentTooltipRef = useRef<TooltipState | null>(null);
   const [map, setMap] = useState(null);
+
+  const MARKER_CONFIG = {
+    SIZE: new kakao.maps.Size(36, 36),
+    OPTIONS: { offset: new kakao.maps.Point(18, 36) },
+  } as const;
 
   const calculateCenterCoordinates = (courses: Course[]) => {
     if (courses.length === 0) {

--- a/frontend/src/hooks/Feed/useFeedSubmit.ts
+++ b/frontend/src/hooks/Feed/useFeedSubmit.ts
@@ -56,10 +56,11 @@ const useFeedSubmit = ({ imageFile, location, navigate }: UseFeedSubmitProps) =>
 
     if (!imageFile || isPasswordError || isContentError) return;
 
-    // 주변 트리 탐색 후 트리가 있다면 가장 가까운 트리 ID에 피드 제출
-    let currentTreeId = trees.length > 0 ? trees[0].id : 0;
+    // 주변 트리 탐색 후 10m이내에 트리가 있다면 가장 가까운 트리 ID에 피드 제출
+    let currentTreeId = trees.length > 0 ? trees[0].id : null;
+    const isExistingTree = trees.some((tree) => tree.distance <= 10);
 
-    if (!trees || trees.length === 0 || currentTreeId === 0) {
+    if (!trees || trees.length === 0 || !isExistingTree || currentTreeId === null) {
       currentTreeId = await addTree({
         latitude: center.latitude,
         longitude: center.longitude,

--- a/frontend/src/mocks/data/trees.json
+++ b/frontend/src/mocks/data/trees.json
@@ -3,36 +3,42 @@
     "id": 1,
     "latitude": 37.574187,
     "longitude": 126.976882,
-    "imageCode": "TREE_01"
+    "imageCode": "TREE_01",
+    "distance": 5
   },
   {
     "id": 2,
     "latitude": 37.5745,
     "longitude": 126.9772,
-    "imageCode": "TREE_01"
+    "imageCode": "TREE_01",
+    "distance": 11.2
   },
   {
     "id": 3,
     "latitude": 37.5738,
     "longitude": 126.9766,
-    "imageCode": "TREE_01"
+    "imageCode": "TREE_01",
+    "distance": 24.213214
   },
   {
     "id": 4,
     "latitude": 37.5741,
     "longitude": 126.977,
-    "imageCode": "TREE_01"
+    "imageCode": "TREE_01",
+    "distance": 2.43534
   },
   {
     "id": 5,
     "latitude": 37.5739,
     "longitude": 126.9768,
-    "imageCode": "TREE_01"
+    "imageCode": "TREE_01",
+    "distance": 234.5546
   },
   {
     "id": 6,
     "latitude": 37.5743,
     "longitude": 126.9774,
-    "imageCode": "TREE_01"
+    "imageCode": "TREE_01",
+    "distance": 435.234324
   }
 ]


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #209

## ✨ 구현한 기능

- 신규 트리 생성 기준을 10m로 변경

## ✏️ 자세한 구현 내용

- 배경
  - 이전의 트리 생성 정책은 반경 2km 이내에 트리가 있다면 트리를 신규로 생성하지 않고, 가장 가까운 트리에 피드를 추가하는 방식이었습니다. 하지만 2km 범위 제한은 가게나 길거리 곳곳의 트리들을 개별적으로 담아내지 못할 것으로 생각하여 범위 기준 정책을 10m로 변경했습니다.

- 변경된 제출 로직
  - 피드 제출 시 useFeedSubmit에서 center position을 확인한 뒤, getTrees를 통해 주변 트리 정보를 가져옵니다.
  - getTrees 호출 시 서버에서는 요청한 좌표를 기준으로 반경 2km 이내에 있는 트리를 응답합니다.
  - getTrees로 응답받은 trees의 distance 필드를 확인하여 10 이하인 값이 존재할 때만 새로운 트리를 추가하는 요청을 전송합니다.
