### PR TITLE
[FE] 피드 삭제 시 트리가 지도에 남아있는 현상 해결 #201

### DIFF
--- a/frontend/src/hooks/TreeMap/useTreeMap.ts
+++ b/frontend/src/hooks/TreeMap/useTreeMap.ts
@@ -12,6 +12,7 @@ const MARKER_IMAGE: Record<string, string> = {
 const useTreeMap = () => {
   const mapRef = useRef<HTMLDivElement | null>(null);
   const [map, setMap] = useState<typeof kakao.maps.Map | null>(null);
+  const currentMarkers = useRef<(typeof kakao.maps.Marker)[]>([]);
 
   const initialCenter = useMemo(() => {
     const saved = sessionStorage.getItem('userLocation');
@@ -48,6 +49,12 @@ const useTreeMap = () => {
     });
     if (onClick) kakao.maps.event.addListener(marker, 'click', onClick);
     marker.setMap(map);
+    currentMarkers.current.push(marker);
+  };
+
+  const clearMarkers = () => {
+    currentMarkers.current.forEach((marker) => marker.setMap(null));
+    currentMarkers.current = [];
   };
 
   const updateCenterPosition = () => {
@@ -61,13 +68,15 @@ const useTreeMap = () => {
 
   useEffect(() => {
     initializeMap(initialCenter.latitude, initialCenter.longitude);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialCenter.latitude, initialCenter.longitude]);
 
   return {
     map,
     mapRef,
     centerPosition,
     addMarker,
+    clearMarkers,
     updateCenterPosition,
   };
 };

--- a/frontend/src/pages/TreeMap/TreeMap.tsx
+++ b/frontend/src/pages/TreeMap/TreeMap.tsx
@@ -16,7 +16,7 @@ const TreeMap = () => {
   const navigate = useNavigate();
 
   const { isModalOpen, openModal, closeModal } = useModal();
-  const { map, mapRef, addMarker, centerPosition, updateCenterPosition } = useTreeMap();
+  const { map, mapRef, addMarker, centerPosition, updateCenterPosition, clearMarkers } = useTreeMap();
   const { trees, isSuccess, isLoading } = useTreesQuery(centerPosition);
 
   const handleMarkerClick = (treeId: number) => {
@@ -27,10 +27,12 @@ const TreeMap = () => {
   useEffect(() => {
     if (map === null || !isSuccess) return;
 
+    clearMarkers();
     trees.forEach((tree) =>
       addMarker(map, tree.latitude, tree.longitude, tree.imageCode, () => handleMarkerClick(tree.id)),
     );
-  }, [map, isSuccess, centerPosition]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, isSuccess, centerPosition, trees]);
 
   const searchParams = useMemo(() => new URLSearchParams(location.search), [location]);
   const modalType = searchParams.get('modal');
@@ -51,6 +53,7 @@ const TreeMap = () => {
     } else {
       closeModal();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modalType, location]);
 
   return (

--- a/frontend/src/queries/Feed/useFeedMutation.ts
+++ b/frontend/src/queries/Feed/useFeedMutation.ts
@@ -3,7 +3,7 @@ import { queryClient } from '@/main';
 import { Feed } from '@/types/feed.type';
 import { useMutation } from '@tanstack/react-query';
 import { deleteFeed, deleteLikeFeed, postFeed, postFeedPassword, postLikeFeed, updateFeed } from '@/apis/feed';
-import { FEED_KEYS } from '../queryKeys';
+import { FEED_KEYS, TREE_KEYS } from '../queryKeys';
 
 const useFeedMutation = () => {
   const navigate = useNavigate();
@@ -94,6 +94,7 @@ const useFeedMutation = () => {
   const { mutate: deleteFeedMutation } = useMutation({
     mutationFn: deleteFeed,
     onSuccess: ({ treeId }) => {
+      queryClient.invalidateQueries({ queryKey: [TREE_KEYS.TREES] });
       queryClient.invalidateQueries({ queryKey: [FEED_KEYS.FEEDS, { treeId }] });
     },
   });


### PR DESCRIPTION
## 📌 연관된 이슈

- closes #201 

## ✨ 구현한 기능

- 피드가 전부 삭제되어 트리도 함께 삭제되는 경우 지도에 삭제된 트리 마커가 여전히 남아있는 현상을 해결했습니다.

## ✏️ 자세한 구현 내용

- 트리 삭제 시 Tanstack query의 trees 캐싱을 무효화
- `/map` 라우트에서 마커를 추가하기 전 `clearMarkers`로 마커를 초기화하는 로직 추가
