### PR TITLE
[BE] zoom level에 따라 클러스터 개수 다르게 설정 #Issue 214

### DIFF
--- a/backend/src/main/java/com/christmas/tree/service/TreeClusterService.java
+++ b/backend/src/main/java/com/christmas/tree/service/TreeClusterService.java
@@ -16,18 +16,23 @@ import org.springframework.stereotype.Service;
 @Service
 public class TreeClusterService {
 
-    private static final int NUM_CLUSTERS = 5;
-    private static final int MAX_ITERATIONS = 1000;
+    private static final int MAX_ITERATIONS = 100;
 
     private final RandomIntPicker randomIntPicker;
 
-    public List<TreeCluster> toCluster(final List<TreeEntity> trees) {
+    public List<TreeCluster> toCluster(final List<TreeEntity> trees, final int zoomLevel) {
+        if (trees.size() < 5) {
+            return trees.stream()
+                    .map(tree -> new TreeCluster(new Coordinate(tree.getLocation().getX(), tree.getLocation().getY()), List.of()))
+                    .toList();
+        }
         final List<TreeClusterPoint> treePoints = trees.stream()
                 .map(TreeClusterPoint::new)
                 .toList();
+        final int clusterCount = getClusterCountByZoomLevel(zoomLevel, trees.size());
         final KMeansPlusPlusClusterer<TreeClusterPoint> clusterGenerator =
                 new KMeansPlusPlusClusterer<>(
-                        NUM_CLUSTERS,
+                        clusterCount,
                         MAX_ITERATIONS,
                         new EuclideanDistance()
                 );
@@ -45,5 +50,16 @@ public class TreeClusterService {
                     return new TreeCluster(center, members);
                 })
                 .toList();
+    }
+
+    private int getClusterCountByZoomLevel(int zoomLevel, int dataSize) {
+        final int baseZoom = 5;
+        final int zoomFactor = Math.max(0, zoomLevel - baseZoom);
+
+        int kByZoom = 3 + (zoomFactor * 2);
+        int kByDataDensity = dataSize / 4;
+        int k = Math.min(kByZoom, kByDataDensity);
+
+        return Math.max(2, Math.min(k, 20));
     }
 }

--- a/backend/src/main/java/com/christmas/tree/service/TreeClusterService.java
+++ b/backend/src/main/java/com/christmas/tree/service/TreeClusterService.java
@@ -21,7 +21,7 @@ public class TreeClusterService {
     private final RandomIntPicker randomIntPicker;
 
     public List<TreeCluster> toCluster(final List<TreeEntity> trees, final int zoomLevel) {
-        if (trees.size() < 5) {
+        if (trees.isEmpty() || trees.size() < 5) {
             return trees.stream()
                     .map(tree -> new TreeCluster(new Coordinate(tree.getLocation().getX(), tree.getLocation().getY()), List.of()))
                     .toList();

--- a/backend/src/main/java/com/christmas/tree/service/TreeService.java
+++ b/backend/src/main/java/com/christmas/tree/service/TreeService.java
@@ -44,7 +44,7 @@ public class TreeService {
     public List<TreeClusterGetResponse> getTreeByCluster(final TreeClusterGetRequest request) {
         final List<TreeEntity> trees = treeRepository.findAllWithinBounds(request.topLeft().longitude(),
                 request.topLeft().latitude(), request.bottomRight().longitude(), request.bottomRight().latitude());
-        final List<TreeCluster> clusters = treeClusterService.toCluster(trees);
+        final List<TreeCluster> clusters = treeClusterService.toCluster(trees, request.zoom());
         return clusters.stream()
                 .map(cluster -> new TreeClusterGetResponse(
                         cluster.center().longitude(),

--- a/backend/src/test/java/com/christmas/tree/service/TreeClusterServiceTest.java
+++ b/backend/src/test/java/com/christmas/tree/service/TreeClusterServiceTest.java
@@ -37,7 +37,7 @@ class TreeClusterServiceTest {
         final List<TreeEntity> trees = KOREA_COORDINATES;
 
         // when
-        final List<TreeCluster> actual = treeClusterService.toCluster(trees);
+        final List<TreeCluster> actual = treeClusterService.toCluster(trees, 2);
         for (TreeCluster tc : actual) {
             System.out.print(tc.center().longitude() + ", "+ tc.center().latitude() + ": ");
             for (TreeEntity tree : tc.members()) {


### PR DESCRIPTION
## 📌 연관된 이슈

- closes: #214 

## ✨ 구현한 기능
- 기존 클러스터링 코드에 줌 레벨에 따라 클러스터 개수를 다르게 구현
- 트리 데이터 개수가 5개 미만이면 클러스터링 적용하지 않도록 수정
